### PR TITLE
Add type hints for attributes

### DIFF
--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -1,7 +1,7 @@
 import typing
 from dataclasses import dataclass
 from mailbox import Mailbox
-from typing import Callable, Union
+from typing import Callable, ClassVar, Union
 
 
 def get_local_function():
@@ -19,7 +19,25 @@ class Class:
     :param x: foo
     :param y: bar
     :param z: baz
+
+    .. attribute:: x
+
+       Multiline
+
+       Description
+
+    .. attribute:: y
+       
+       bar
+
+    .. attribute:: z
+
+       baz
     """
+
+    x: bool
+    y: int
+    z: ClassVar[str]
 
     def __init__(self, x: bool, y: int, z: typing.Optional[str] = None) -> None:
         pass
@@ -83,7 +101,11 @@ class Class:
     class InnerClass:
         """
         Inner class.
+
+        :ivar x: foo
         """
+
+        x: bool
 
         def inner_method(self, x: bool) -> str:
             """
@@ -106,8 +128,14 @@ class DummyException(Exception):
     """
     Exception docstring
 
+    .. attribute:: message
+
+       Message description
+
     :param message: blah
     """
+
+    message: str
 
     def __init__(self, message: str) -> None:
         super().__init__(message)

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -27,7 +27,7 @@ class Class:
        Description
 
     .. attribute:: y
-       
+
        bar
 
     .. attribute:: z

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -274,11 +274,39 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
               * **z** ("Optional"["str"]) – baz
 
+           x
+
+              Multiline
+
+              Description
+
+              Type:
+                 "bool"
+
+           y
+
+              bar
+
+              Type:
+                 "int"
+
+           z
+         
+              baz
+
+              Type:
+                 "ClassVar"["str"]
+
            class InnerClass
 
               Inner class.
 
               __dunder_inner_method(x)
+
+              Variables:
+                 **x** ("bool") -- foo
+
+              _InnerClass__dunder_inner_method(x)
 
                  Dunder inner method.
 
@@ -299,6 +327,10 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
                     "str"
 
            __dunder_method(x)
+           
+              x: bool = None
+
+           _Class__dunder_method(x)
 
               Dunder method docstring.
 
@@ -384,12 +416,27 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               Return type:
                  "str"
 
+           x: bool = None
+
+           y: int = None
+
+           z: ClassVar[str] = None
+
         exception dummy_module.DummyException(message)
 
            Exception docstring
 
+           message
+
+              Message description
+
+              Type:
+                 "str"
+
            Parameters:
               **message** ("str") – blah
+
+           message: str = None
 
         dummy_module.function(x, y, z_=None)
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -291,7 +291,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
                  "int"
 
            z
-         
+
               baz
 
               Type:


### PR DESCRIPTION
Reopening https://github.com/agronholm/sphinx-autodoc-typehints/pull/143 with a new branch.

Partially resolves #44, although not for inline comments.