### PR TITLE
Support getting methods using metaclasses

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -253,7 +253,7 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
                 class_name = obj.__qualname__.split('.')[-2]
                 method_name = "_{c}{m}".format(c=class_name, m=method_name)
 
-            method_object = outer.__dict__[method_name] if outer else obj
+            method_object = getattr(outer, method_name) if outer else obj
             if not isinstance(method_object, (classmethod, staticmethod)):
                 del parameters[0]
 


### PR DESCRIPTION
If a metaclass has a `__getattr__` method, `__dict__` won’t cut it.