### PR TITLE
Bugfix for Python 3.9

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -143,6 +143,14 @@ def format_annotation(annotation,
             for arg in args[:-1]) + ']'
         formatted_args += ', ' + format_annotation(
             args[-1], simplify_optional_unions=simplify_optional_unions) + ']'
+    elif full_name == 'collections.abc.Callable' and args and args[0] is not ...:
+        assert len(args) == 2
+        formatted_args = '\\[\\[' + ', '.join(
+            format_annotation(
+                arg, simplify_optional_unions=simplify_optional_unions)
+            for arg in args[0]) + ']'
+        formatted_args += ', ' + format_annotation(
+            args[-1], simplify_optional_unions=simplify_optional_unions) + ']'
     elif full_name == 'typing.Literal':
         formatted_args = '\\[' + ', '.join(repr(arg) for arg in args) + ']'
 

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -118,7 +118,7 @@ def format_annotation(annotation,
 
     full_name = (module + '.' + class_name) if module != 'builtins' else class_name
     prefix = '' if fully_qualified or full_name == class_name else '~'
-    role = 'data' if class_name in pydata_annotations else 'class'
+    role = 'data' if class_name in pydata_annotations and module != 'collections.abc' else 'class'
     args_format = '\\[{}]'
     formatted_args = ''
 

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -136,19 +136,17 @@ def format_annotation(annotation,
             full_name = 'typing.Optional'
             args_format = '\\[:py:data:`{prefix}typing.Union`\\[{{}}]]'.format(prefix=prefix)
             args = tuple(x for x in args if x is not type(None))  # noqa: E721
-    elif full_name == 'typing.Callable' and args and args[0] is not ...:
+    elif full_name in ['typing.Callable', 'collections.abc.Callable'] \
+            and args and args[0] is not ...:
+        try:
+            iter(args[0])
+            arglist = args[0]
+        except TypeError:
+            arglist = args[:-1]
         formatted_args = '\\[\\[' + ', '.join(
             format_annotation(
                 arg, simplify_optional_unions=simplify_optional_unions)
-            for arg in args[:-1]) + ']'
-        formatted_args += ', ' + format_annotation(
-            args[-1], simplify_optional_unions=simplify_optional_unions) + ']'
-    elif full_name == 'collections.abc.Callable' and args and args[0] is not ...:
-        assert len(args) == 2
-        formatted_args = '\\[\\[' + ', '.join(
-            format_annotation(
-                arg, simplify_optional_unions=simplify_optional_unions)
-            for arg in args[0]) + ']'
+            for arg in arglist) + ']'
         formatted_args += ', ' + format_annotation(
             args[-1], simplify_optional_unions=simplify_optional_unions) + ']'
     elif full_name == 'typing.Literal':

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -138,11 +138,7 @@ def format_annotation(annotation,
             args = tuple(x for x in args if x is not type(None))  # noqa: E721
     elif full_name in ['typing.Callable', 'collections.abc.Callable'] \
             and args and args[0] is not ...:
-        try:
-            iter(args[0])
-            arglist = args[0]
-        except TypeError:
-            arglist = args[:-1]
+        arglist = args[0] if isinstance(args[0], list) else args[:-1]
         formatted_args = '\\[\\[' + ', '.join(
             format_annotation(
                 arg, simplify_optional_unions=simplify_optional_unions)

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -1,10 +1,12 @@
 import typing
 from mailbox import Mailbox
-from typing import Callable, Union
+from typing import Union
 
 import sys
 if sys.version_info.major == 3 and sys.version_info.minor >= 9:
     from collections.abc import Callable
+else:
+    from typing import Callable
 
 try:
     from dataclasses import dataclass

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -1,7 +1,16 @@
 import typing
-from dataclasses import dataclass
 from mailbox import Mailbox
 from typing import Callable, Union
+
+import sys
+if sys.version_info.major == 3 and sys.version_info.minor >= 9:
+    from collections.abc import Callable
+
+try:
+    from dataclasses import dataclass
+except ImportError:
+    def dataclass(cls):
+        return cls
 
 
 def get_local_function():
@@ -232,6 +241,28 @@ class ClassWithTypehintsNotInline(object):
         :param x: foo
         """
         return cls(x)
+
+
+def function_with_collections_abc_Callable(func: Callable[[str], str], x: str
+                                           ) -> str:
+    """
+    Docstring with collections.abc.Callable.
+
+    :param func: foo
+    """
+
+    return func(x)
+
+
+def function_with_collections_abc_Callable_ellipsis_args(func: Callable[..., str],
+                                                         *args, **kwargs) -> str:
+    """
+    Docstring with collections.abc.Callable and ellipsis in arg list.
+
+    :param func: foo
+    """
+
+    return func(*args, **kwargs)
 
 
 def undocumented_function(x: int) -> str:

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -251,6 +251,7 @@ def function_with_collections_abc_Callable(func: Callable[[str], str], x: str
     Docstring with collections.abc.Callable.
 
     :param func: foo
+    :param x: bar
     """
 
     return func(x)

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -1,12 +1,12 @@
 import sys
 import typing
 from mailbox import Mailbox
-from typing import Union
+from typing import Any, Callable, Union
 
 if sys.version_info.major == 3 and sys.version_info.minor >= 9:
-    from collections.abc import Callable
+    from collections.abc import Callable as ABCCallable
 else:
-    from typing import Callable
+    from typing import Callable as ABCCallable
 
 try:
     from dataclasses import dataclass
@@ -245,8 +245,8 @@ class ClassWithTypehintsNotInline(object):
         return cls(x)
 
 
-def function_with_collections_abc_Callable(func: Callable[[str], str], x: str
-                                           ) -> str:
+def function_with_collections_abc_Callable(func: ABCCallable[[str], str],
+                                           x: str) -> str:
     """
     Docstring with collections.abc.Callable.
 
@@ -257,7 +257,7 @@ def function_with_collections_abc_Callable(func: Callable[[str], str], x: str
     return func(x)
 
 
-def function_with_collections_abc_Callable_ellipsis_args(func: Callable[..., str],
+def function_with_collections_abc_Callable_ellipsis_args(func: ABCCallable[..., str],
                                                          *args, **kwargs) -> str:
     """
     Docstring with collections.abc.Callable and ellipsis in arg list.
@@ -266,6 +266,18 @@ def function_with_collections_abc_Callable_ellipsis_args(func: Callable[..., str
     """
 
     return func(*args, **kwargs)
+
+
+def function_with_typing_Callable_Any(func: Callable[[Any], str],
+                                      x: Any) -> str:
+    """
+    Docstring with typing.Callable and Any.
+
+    :param func: foo
+    :param x: bar
+    """
+
+    return func(x)
 
 
 def undocumented_function(x: int) -> str:

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -1,8 +1,8 @@
+import sys
 import typing
 from mailbox import Mailbox
 from typing import Union
 
-import sys
 if sys.version_info.major == 3 and sys.version_info.minor >= 9:
     from collections.abc import Callable
 else:

--- a/tests/roots/test-dummy/index.rst
+++ b/tests/roots/test-dummy/index.rst
@@ -27,6 +27,10 @@ Dummy Module
 .. autoclass:: dummy_module.ClassWithTypehintsNotInline
    :members:
 
+.. autofunction:: dummy_module.function_with_collections_abc_Callable
+
+.. autofunction:: dummy_module.function_with_collections_abc_Callable_ellipsis_args
+
 .. autofunction:: dummy_module.undocumented_function
 
 .. autoclass:: dummy_module.DataClass

--- a/tests/roots/test-dummy/index.rst
+++ b/tests/roots/test-dummy/index.rst
@@ -31,6 +31,8 @@ Dummy Module
 
 .. autofunction:: dummy_module.function_with_collections_abc_Callable_ellipsis_args
 
+.. autofunction:: dummy_module.function_with_typing_Callable_Any
+
 .. autofunction:: dummy_module.undocumented_function
 
 .. autoclass:: dummy_module.DataClass

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -504,8 +504,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Docstring with collections.abc.Callable.
 
            Parameters:
-              **func** ("Callable"[["str"], "str"]) --
-              foo
+              **func** ("Callable"[["str"], "str"]) -- foo
 
            Return type:
               "str"
@@ -515,8 +514,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Docstring with collections.abc.Callable and ellipsis in arg list.
 
            Parameters:
-              **func** ("Callable"[["..."], "str"]) --
-              foo
+              **func** ("Callable"[..., "str"]) -- foo
 
            Return type:
               "str"

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -521,6 +521,18 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Return type:
               "str"
 
+        dummy_module.function_with_typing_Callable_Any(func, x)
+
+           Docstring with typing.Callable and Any.
+
+           Parameters:
+              * **func** ("Callable"[["Any"], "str"]) -- foo
+
+              * **x** ("Any") -- bar
+
+           Return type:
+              "str"
+
         dummy_module.undocumented_function(x)
 
            Hi{undoc_params_0}

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -514,7 +514,8 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Docstring with collections.abc.Callable and ellipsis in arg list.
 
            Parameters:
-              **func** ("Callable"[..., "str"]) -- foo
+              * **func** ("Callable"[..., "str"]) -- foo
+              * **x** ("str") -- bar
 
            Return type:
               "str"

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -504,7 +504,9 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Docstring with collections.abc.Callable.
 
            Parameters:
-              **func** ("Callable"[["str"], "str"]) -- foo
+              * **func** ("Callable"[["str"], "str"]) -- foo
+
+              * **x** ("str") -- bar
 
            Return type:
               "str"
@@ -514,8 +516,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Docstring with collections.abc.Callable and ellipsis in arg list.
 
            Parameters:
-              * **func** ("Callable"[..., "str"]) -- foo
-              * **x** ("str") -- bar
+              **func** ("Callable"[..., "str"]) -- foo
 
            Return type:
               "str"

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -523,13 +523,6 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
         dummy_module.undocumented_function(x)
 
-           Hi{undoc_params}
-
-           Return type:
-              "str"
-
-        dummy_module.undocumented_function(x)
-
            Hi{undoc_params_0}
 
            Return type:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -512,7 +512,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
         dummy_module.function_with_collections_abc_Callable_ellipsis_args(func, *args, **kwargs)
 
-	   Docstring with collections.abc.Callable and ellipsis in arg list.
+           Docstring with collections.abc.Callable and ellipsis in arg list.
 
            Parameters:
               **func** ("Callable"[["..."], "str"]) --

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -499,6 +499,35 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               Return type:
                  "ClassWithTypehintsNotInline"
 
+        dummy_module.function_with_collections_abc_Callable(func, x)
+
+           Docstring with collections.abc.Callable.
+
+           Parameters:
+              **func** ("Callable"[["str"], "str"]) --
+              foo
+
+           Return type:
+              "str"
+
+        dummy_module.function_with_collections_abc_Callable_ellipsis_args(func, *args, **kwargs)
+
+	   Docstring with collections.abc.Callable and ellipsis in arg list.
+
+           Parameters:
+              **func** ("Callable"[["..."], "str"]) --
+              foo
+
+           Return type:
+              "str"
+
+        dummy_module.undocumented_function(x)
+
+           Hi{undoc_params}
+
+           Return type:
+              "str"
+
         dummy_module.undocumented_function(x)
 
            Hi{undoc_params_0}


### PR DESCRIPTION
## Overview

In Python 3.9, `typing.Callable` is deprecated, in favor of `collections.abc.Callable`. Thus, the code needs to be updated accordingly.

## Reason

`get_type_hints` for `collections.abc.Callable` returns in format `[[…], …]` instead of `[…, …]`, the latter of which is the case for `typing.Callable`.

Additionally, `collections.abc.Callable` is a `class` instead of `data`.



## Example

With `typehints_fully_qualified = True` for clarity.

Tested on `Python 3.9.1 (tags/v3.9.1:1e5d33e, Dec  7 2020, 17:08:21) [MSC v.1927 64 bit (AMD64)] on win32`.

### Should be
![1](https://user-images.githubusercontent.com/17482970/112716674-11cdd580-8f2b-11eb-9645-c49e1e0a5e5f.png)

### But got
![2](https://user-images.githubusercontent.com/17482970/112716655-fbc01500-8f2a-11eb-8ae0-d43341b24986.png)
 
### After the bugfix
![3](https://user-images.githubusercontent.com/17482970/112716658-02e72300-8f2b-11eb-8668-762aa61a1985.png) 
