### PR TITLE
Added default and class value settings. Any interest?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,10 @@ The following configuration options are accepted:
   Note: If ``False``, **any** Union containing ``None`` will be displayed as Optional!
   Note: If an optional parameter has only a single type (e.g Optional[A] or Union[A, None]),
   it will **always** be displayed as Optional!
+* ``keep_default_values`` (default: ``True``): Default values are kept in the documentation. 
+  If set to ``False`` default values are not shown.
+* ``hide_class_values`` (default ``False``): If set to ``True`` ``__init__`` values are hidden in
+  the class directive. ``Class(value):`` becomes ``Class:``.
 
 How it works
 ------------

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -267,9 +267,14 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
     # Removes the default values from the signature; e.g `def foo(a: int = 10)` 
     # becomes `def foo(a: int)`.
     if not app.config.keep_default_values and signature:
-        search = re.findall(r"(\w*)=", signature)
-        if search:
-            signature = "({})".format(", ".join([s for s in search]))
+        items = []
+        line = signature[1:-1]
+        for item in line.split(','):
+            item = item.strip()
+            if "=" in item:
+                item = item.split('=')[0].strip()
+            items.append(item)
+        signature = "({})".format(", ".join([item for item in items if item]))
 
     # Removes the class values; e.g. 'Class(val, val, val):' becomes 'Class:'.
     if app.config.hide_class_values and what == "class":


### PR DESCRIPTION
I needed these modifications for my own projects, and figured I would open a PR to ask if this is something that you guys might want to add to the project (I fully understand if not as it is a very niche setting). In short, two flags have been added:

### `keep_default_values` (defaults to `True`)

Default values are kept in the documentation. If set to ``False`` default values are not shown.

#### `True`
<img width="600" alt="Screen Shot 2021-11-06 at 8 42 58 PM" src="https://user-images.githubusercontent.com/2829082/140628079-38454a7d-28ca-4769-a924-96f2494ab3c4.png">

#### `False`
<img width="600" alt="Screen Shot 2021-11-06 at 8 43 13 PM" src="https://user-images.githubusercontent.com/2829082/140628083-c96f60b0-19f8-406a-9ec0-0548466af244.png">

### `hide_class_values` (defaults to `False`)

If set to ``True`` ``__init__`` values are hidden in the class directive. ``Class(value):`` becomes ``Class:``.

#### `True`
<img width="600" alt="Screen Shot 2021-11-06 at 8 42 58 PM" src="https://user-images.githubusercontent.com/2829082/140628079-38454a7d-28ca-4769-a924-96f2494ab3c4.png">

#### `False`

<img width="600" alt="Screen Shot 2021-11-06 at 8 44 09 PM" src="https://user-images.githubusercontent.com/2829082/140628090-37461d54-7fd9-4422-8139-e2e7630af48f.png">

This PR is missing tests to go along with it. Also, as I write this PR I've noticed that keeping counter opposite flags (`keep` and `hide`) is a bit redundant - I can also change this.