### PR TITLE
Add defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-- Added `document_defaults` config value allowing to automatically annotate parameter defaults.
+- Added `document_defaults` config option allowing to automatically annotate parameter defaults.
 
 ## 1.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## dev
+
+- Added `document_defaults` config value allowing to automatically annotate parameter defaults.
+
 ## 1.13.0
 
 - Dropped Python 3.6 support

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ The following configuration options are accepted:
   `True`, add stub documentation for undocumented parameters to be able to add type info.
 - `typehints_document_rtype` (default: `True`): If `False`, never add an `:rtype:` directive. If `True`, add the
   `:rtype:` directive if no existing `:rtype:` is found.
+- `document_defaults` (default: `None`): If `None`, defaults are not added. Otherwise adds a default annotation:
+
+  - `'comma'` adds it after the type, changing Sphinx’ default look to “**param** (*int*, default: `1`) -- text”.
+  - `'braces'` adds `(default: ...)` after the type (useful for numpydoc like styles).
+  - `'braces-after'` adds `(default: ...)` at the end of the parameter documentation text instead.
+
 - `simplify_optional_unions` (default: `True`): If `True`, optional parameters of type \"Union\[\...\]\" are simplified
   as being of type Union\[\..., None\] in the resulting documention (e.g. Optional\[Union\[A, B\]\] -\> Union\[A, B,
   None\]). If `False`, the \"Optional\"-type is kept. Note: If `False`, **any** Union containing `None` will be

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -427,8 +427,6 @@ def split_type_comment_args(comment):
 
 
 def format_default(app: Sphinx, default: Any) -> Optional[str]:
-    if not app.config.typehints_defaults:
-        return None
     if default is inspect.Parameter.empty:
         return None
     formatted = repr(default).replace("\\", "\\\\")

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -2,7 +2,7 @@ import inspect
 import sys
 import textwrap
 import typing
-from typing import Any, AnyStr, NewType, Tuple, TypeVar, get_type_hints
+from typing import Any, AnyStr, Dict, NewType, Optional, Tuple, TypeVar, get_type_hints
 
 from sphinx.application import Sphinx
 from sphinx.util import logging
@@ -426,7 +426,7 @@ def split_type_comment_args(comment):
     return result
 
 
-def format_default(app: Sphinx, default):
+def format_default(app: Sphinx, default: Any) -> Optional[str]:
     if not app.config.typehints_defaults:
         return None
     if default is inspect.Parameter.empty:
@@ -516,7 +516,7 @@ def process_docstring(app: Sphinx, what, name, obj, options, lines):  # noqa: U1
                 lines.insert(insert_index, f":rtype: {formatted_annotation}")
 
 
-def builder_ready(app: Sphinx):
+def builder_ready(app: Sphinx) -> None:
     if app.config.set_type_checking_flag:
         typing.TYPE_CHECKING = True
     valid = {None, "comma", "braces", "braces-after"}
@@ -524,7 +524,7 @@ def builder_ready(app: Sphinx):
         raise ValueError(f"typehints_defaults needs to be one of {valid!r}, not {app.config.typehints_defaults!r}")
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> Dict[str, bool]:
     app.add_config_value("set_type_checking_flag", False, "html")
     app.add_config_value("always_document_param_types", False, "html")
     app.add_config_value("typehints_fully_qualified", False, "env")

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -454,6 +454,7 @@ def process_docstring(app: Sphinx, what, name, obj, options, lines):  # noqa: U1
         for arg_name, annotation in type_hints.items():
             if arg_name == "return":
                 continue  # this is handled separately later
+            default = signature.parameters[arg_name].default
             if arg_name.endswith("_"):
                 arg_name = f"{arg_name[:-1]}\\_"
 
@@ -478,11 +479,12 @@ def process_docstring(app: Sphinx, what, name, obj, options, lines):  # noqa: U1
             if insert_index is not None:
                 type_annotation = f":type {arg_name}: {formatted_annotation}"
                 if app.config.typehints_defaults:
-                    default = format_default(app, signature.parameters[arg_name].default)
-                    if app.config.typehints_defaults.endswith("after"):
-                        type_annotation += default
-                    else:  # add to last param doc line
-                        lines[insert_index] += default
+                    formatted_default = format_default(app, default)
+                    if formatted_default:
+                        if app.config.typehints_defaults.endswith("after"):
+                            lines[insert_index] += formatted_default
+                        else:  # add to last param doc line
+                            type_annotation += formatted_default
                 lines.insert(insert_index, type_annotation)
 
         if "return" in type_hints and not inspect.isclass(original_obj):

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -4,6 +4,7 @@ import textwrap
 import typing
 from typing import Any, AnyStr, NewType, Tuple, TypeVar, get_type_hints
 
+from sphinx.application import Sphinx
 from sphinx.util import logging
 from sphinx.util.inspect import signature as sphinx_signature
 from sphinx.util.inspect import stringify_signature
@@ -425,7 +426,19 @@ def split_type_comment_args(comment):
     return result
 
 
-def process_docstring(app, what, name, obj, options, lines):  # noqa: U100
+def format_default(app: Sphinx, default):
+    if not app.config.typehints_defaults:
+        return None
+    if default is inspect.Parameter.empty:
+        return None
+    formatted = repr(default).replace("\\", "\\\\")
+    if app.config.typehints_defaults.startswith("braces"):
+        return f" (default: ``{formatted}``)"
+    else:
+        return f", default: ``{formatted}``"
+
+
+def process_docstring(app: Sphinx, what, name, obj, options, lines):  # noqa: U100
     original_obj = obj
     if isinstance(obj, property):
         obj = obj.fget
@@ -441,7 +454,6 @@ def process_docstring(app, what, name, obj, options, lines):  # noqa: U100
         for arg_name, annotation in type_hints.items():
             if arg_name == "return":
                 continue  # this is handled separately later
-            default = signature.parameters[arg_name].default
             if arg_name.endswith("_"):
                 arg_name = f"{arg_name[:-1]}\\_"
 
@@ -464,9 +476,14 @@ def process_docstring(app, what, name, obj, options, lines):  # noqa: U100
                 insert_index = len(lines)
 
             if insert_index is not None:
-                if default is not inspect.Parameter.empty:
-                    lines[insert_index] += f" (default: ``{default!r}``)".replace("\\", "\\\\")
-                lines.insert(insert_index, f":type {arg_name}: {formatted_annotation}")
+                type_annotation = f":type {arg_name}: {formatted_annotation}"
+                if app.config.typehints_defaults:
+                    default = format_default(app, signature.parameters[arg_name].default)
+                    if app.config.typehints_defaults.endswith("after"):
+                        type_annotation += default
+                    else:  # add to last param doc line
+                        lines[insert_index] += default
+                lines.insert(insert_index, type_annotation)
 
         if "return" in type_hints and not inspect.isclass(original_obj):
             # This avoids adding a return type for data class __init__ methods
@@ -497,16 +514,20 @@ def process_docstring(app, what, name, obj, options, lines):  # noqa: U100
                 lines.insert(insert_index, f":rtype: {formatted_annotation}")
 
 
-def builder_ready(app):
+def builder_ready(app: Sphinx):
     if app.config.set_type_checking_flag:
         typing.TYPE_CHECKING = True
+    valid = {None, "comma", "braces", "braces-after"}
+    if app.config.typehints_defaults not in valid | {False}:
+        raise ValueError(f"typehints_defaults needs to be one of {valid!r}, not {app.config.typehints_defaults!r}")
 
 
-def setup(app):
+def setup(app: Sphinx):
     app.add_config_value("set_type_checking_flag", False, "html")
     app.add_config_value("always_document_param_types", False, "html")
     app.add_config_value("typehints_fully_qualified", False, "env")
     app.add_config_value("typehints_document_rtype", True, "env")
+    app.add_config_value("typehints_defaults", None, "env")
     app.add_config_value("simplify_optional_unions", True, "env")
     app.connect("builder-inited", builder_ready)
     app.connect("autodoc-process-signature", process_signature)

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -517,6 +517,9 @@ def process_docstring(app: Sphinx, what, name, obj, options, lines):  # noqa: U1
 def builder_ready(app: Sphinx) -> None:
     if app.config.set_type_checking_flag:
         typing.TYPE_CHECKING = True
+
+
+def validate_config(app: Sphinx, *args) -> None:  # noqa: U100
     valid = {None, "comma", "braces", "braces-after"}
     if app.config.typehints_defaults not in valid | {False}:
         raise ValueError(f"typehints_defaults needs to be one of {valid!r}, not {app.config.typehints_defaults!r}")
@@ -530,6 +533,7 @@ def setup(app: Sphinx) -> Dict[str, bool]:
     app.add_config_value("typehints_defaults", None, "env")
     app.add_config_value("simplify_optional_unions", True, "env")
     app.connect("builder-inited", builder_ready)
+    app.connect("env-before-read-docs", validate_config)  # config may be changed after “config-inited” event
     app.connect("autodoc-process-signature", process_signature)
     app.connect("autodoc-process-docstring", process_docstring)
     return {"parallel_read_safe": True}

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -435,11 +435,13 @@ def process_docstring(app, what, name, obj, options, lines):  # noqa: U100
             obj = obj.__init__
 
         obj = inspect.unwrap(obj)
+        signature = sphinx_signature(obj)
         type_hints = get_all_type_hints(obj, name)
 
         for arg_name, annotation in type_hints.items():
             if arg_name == "return":
                 continue  # this is handled separately later
+            default = signature.parameters[arg_name].default
             if arg_name.endswith("_"):
                 arg_name = f"{arg_name[:-1]}\\_"
 
@@ -462,6 +464,8 @@ def process_docstring(app, what, name, obj, options, lines):  # noqa: U100
                 insert_index = len(lines)
 
             if insert_index is not None:
+                if default is not inspect.Parameter.empty:
+                    lines[insert_index] += f" (default: ``{default!r}``)".replace("\\", "\\\\")
                 lines.insert(insert_index, f":type {arg_name}: {formatted_annotation}")
 
         if "return" in type_hints and not inspect.isclass(original_obj):

--- a/tests/roots/test-dummy/dummy_module_simple.py
+++ b/tests/roots/test-dummy/dummy_module_simple.py
@@ -1,0 +1,7 @@
+def function(x: bool, y: int = 1) -> str:  # noqa: U100
+    """
+    Function docstring.
+
+    :param x: foo
+    :param y: bar
+    """

--- a/tests/roots/test-dummy/simple.rst
+++ b/tests/roots/test-dummy/simple.rst
@@ -1,0 +1,4 @@
+Simple Module
+=============
+
+.. autofunction:: dummy_module_simple.function

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -620,6 +620,7 @@ def test_sphinx_output_future_annotations(app, status):
         ("comma", '("int", default: "1") -- bar'),
         ("braces", '("int" (default: "1")) -- bar'),
         ("braces-after", '("int") -- bar (default: "1")'),
+        ("comma-after", Exception("needs to be one of")),
     ],
 )
 @pytest.mark.sphinx("text", testroot="dummy")
@@ -629,7 +630,13 @@ def test_sphinx_output_defaults(app, status, defaults_config_val, expected):
 
     app.config.master_doc = "simple"
     app.config.typehints_defaults = defaults_config_val
-    app.build()
+    try:
+        app.build()
+    except Exception as e:
+        if not isinstance(expected, Exception):
+            raise
+        assert str(expected) in str(e)
+        return
     assert "build succeeded" in status.getvalue()
 
     text_path = pathlib.Path(app.srcdir) / "_build" / "text" / "simple.txt"

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -614,7 +614,7 @@ def test_sphinx_output_future_annotations(app, status):
 
 
 @pytest.mark.parametrize(
-    ("defaults_confval", "expected"),
+    ("defaults_config_val", "expected"),
     [
         (None, "(*int*) -- bar"),
         ("comma", '(*int*, default: "1") -- bar'),

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -319,7 +319,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
               * **y** ("int") – bar
 
-              * **z** ("Optional"["str"]) – baz (default: "None")
+              * **z** ("Optional"["str"]) – baz
 
            class InnerClass
 
@@ -384,7 +384,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
                  * **y** ("int") – bar
 
-                 * **z** ("Optional"["str"]) – baz (default: "None")
+                 * **z** ("Optional"["str"]) – baz
 
               Return type:
                  "str"
@@ -398,7 +398,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
                  * **y** ("int") – bar
 
-                 * **z** ("Optional"["str"]) – baz (default: "None")
+                 * **z** ("Optional"["str"]) – baz
 
               Return type:
                  "str"
@@ -419,7 +419,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
                  * **y** ("int") – bar
 
-                 * **z** ("Optional"["str"]) – baz (default: "None")
+                 * **z** ("Optional"["str"]) – baz
 
               Return type:
                  "str"
@@ -447,7 +447,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
               * **y** ("int") – bar
 
-              * **z_** ("Optional"["str"]) – baz (default: "None")
+              * **z_** ("Optional"["str"]) – baz
 
            Returns:
               something
@@ -460,7 +460,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Function docstring.
 
            Parameters:
-              **x** ("str") – foo (default: "'\\\\x08'")
+              **x** ("str") – foo
 
         dummy_module.function_with_unresolvable_annotation(x)
 
@@ -507,7 +507,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Function docstring.
 
            Parameters:
-              * **x** ("Union"["str", "bytes", "None"]) -- foo (default: "None")
+              * **x** ("Union"["str", "bytes", "None"]) -- foo
 
               * **y** ("str") -- bar
 
@@ -523,14 +523,14 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Class docstring.
 
            Parameters:
-              **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo (default: "None")
+              **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo
 
            foo(x=1)
 
               Method docstring.
 
               Parameters:
-                 **x** ("Callable"[["int", "bytes"], "int"]) -- foo (default: "1")
+                 **x** ("Callable"[["int", "bytes"], "int"]) -- foo
 
               Return type:
                  "int"
@@ -540,7 +540,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               Method docstring.
 
               Parameters:
-                 **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo (default: "None")
+                 **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo
 
               Return type:
                  "ClassWithTypehintsNotInline"
@@ -604,7 +604,7 @@ def test_sphinx_output_future_annotations(app, status):
 
               * **y** (*int*) -- bar
 
-              * **z** (*str** | **None*) -- baz (default: "None")
+              * **z** (*str** | **None*) -- baz
 
            Return type:
               str

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -267,7 +267,7 @@ def maybe_fix_py310(expected_contents):
         for old, new in [
             ("*str** | **None*", '"Optional"["str"]'),
             ("(*bool*)", '("bool")'),
-            ("(*int*)", '("int")'),
+            ("(*int*", '("int"'),
             ("   str", '   "str"'),
             ('"Optional"["str"]', '"Optional"["str"]'),
             ('"Optional"["Callable"[["int", "bytes"], "int"]]', '"Optional"["Callable"[["int", "bytes"], "int"]]'),

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -319,7 +319,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
               * **y** ("int") – bar
 
-              * **z** ("Optional"["str"]) – baz
+              * **z** ("Optional"["str"]) – baz (default: "None")
 
            class InnerClass
 
@@ -384,7 +384,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
                  * **y** ("int") – bar
 
-                 * **z** ("Optional"["str"]) – baz
+                 * **z** ("Optional"["str"]) – baz (default: "None")
 
               Return type:
                  "str"
@@ -398,7 +398,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
                  * **y** ("int") – bar
 
-                 * **z** ("Optional"["str"]) – baz
+                 * **z** ("Optional"["str"]) – baz (default: "None")
 
               Return type:
                  "str"
@@ -419,7 +419,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
                  * **y** ("int") – bar
 
-                 * **z** ("Optional"["str"]) – baz
+                 * **z** ("Optional"["str"]) – baz (default: "None")
 
               Return type:
                  "str"
@@ -447,7 +447,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
               * **y** ("int") – bar
 
-              * **z_** ("Optional"["str"]) – baz
+              * **z_** ("Optional"["str"]) – baz (default: "None")
 
            Returns:
               something
@@ -460,7 +460,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Function docstring.
 
            Parameters:
-              **x** ("str") – foo
+              **x** ("str") – foo (default: "'\\\\x08'")
 
         dummy_module.function_with_unresolvable_annotation(x)
 
@@ -507,7 +507,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Function docstring.
 
            Parameters:
-              * **x** ("Union"["str", "bytes", "None"]) -- foo
+              * **x** ("Union"["str", "bytes", "None"]) -- foo (default: "None")
 
               * **y** ("str") -- bar
 
@@ -523,14 +523,14 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Class docstring.
 
            Parameters:
-              **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo
+              **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo (default: "None")
 
            foo(x=1)
 
               Method docstring.
 
               Parameters:
-                 **x** ("Callable"[["int", "bytes"], "int"]) -- foo
+                 **x** ("Callable"[["int", "bytes"], "int"]) -- foo (default: "1")
 
               Return type:
                  "int"
@@ -540,7 +540,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               Method docstring.
 
               Parameters:
-                 **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo
+                 **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo (default: "None")
 
               Return type:
                  "ClassWithTypehintsNotInline"
@@ -604,7 +604,7 @@ def test_sphinx_output_future_annotations(app, status):
 
               * **y** (*int*) -- bar
 
-              * **z** (*str** | **None*) -- baz
+              * **z** (*str** | **None*) -- baz (default: "None")
 
            Return type:
               str

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -263,7 +263,7 @@ def set_python_path():
 
 
 def maybe_fix_py310(expected_contents):
-    if sys.version_info[:2] >= (3, 10):
+    if PY310_PLUS:
         for old, new in [
             ("*str** | **None*", '"Optional"["str"]'),
             ("(*bool*)", '("bool")'),
@@ -616,10 +616,10 @@ def test_sphinx_output_future_annotations(app, status):
 @pytest.mark.parametrize(
     ("defaults_config_val", "expected"),
     [
-        (None, "(*int*) -- bar"),
-        ("comma", '(*int*, default: "1") -- bar'),
-        ("braces", '(*int* (default: "1")) -- bar'),
-        ("braces-after", '(*int*) -- bar (default: "1")'),
+        (None, '("int") -- bar'),
+        ("comma", '("int", default: "1") -- bar'),
+        ("braces", '("int" (default: "1")) -- bar'),
+        ("braces-after", '("int") -- bar (default: "1")'),
     ],
 )
 @pytest.mark.sphinx("text", testroot="dummy")
@@ -644,15 +644,15 @@ def test_sphinx_output_defaults(app, status, defaults_config_val, expected):
        Function docstring.
 
        Parameters:
-          * **x** (*bool*) -- foo
+          * **x** ("bool") -- foo
 
           * **y** {expected}
 
        Return type:
-          str
+          "str"
     """
     )
-    assert text_contents == maybe_fix_py310(expected_contents)
+    assert text_contents == expected_contents
 
 
 def test_normalize_source_lines_async_def():

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -16,6 +16,7 @@ func
 getmodule
 getsource
 idx
+inited
 inv
 isfunction
 iterdir


### PR DESCRIPTION
Supersedes #103, fixes #48

In the previous PR, I added them to types, this time I’m adding it to the string. I think both have arguments pro and contra. Should it be configurable?