### PR TITLE
Fix KeyError with type hints on the first arg of bound methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## dev
 
 - Fixed `normalize_source_lines()` messing with the indentation of methods with decorators that have parameters starting with `def`.
+- Handle `ValueError` or `TypeError` being raised when signature of an object cannot be determined
+- Fix `KeyError` being thrown when argument is not documented (e.g. `cls` argument for class methods, and `self` for methods)
 
 ## 1.14.0
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -454,7 +454,10 @@ def process_docstring(
     for arg_name, annotation in type_hints.items():
         if arg_name == "return":
             continue  # this is handled separately later
-        default = inspect.Parameter.empty if signature is None else signature.parameters[arg_name].default
+        if signature is None or arg_name not in signature.parameters:
+            default = inspect.Parameter.empty
+        else:
+            default = signature.parameters[arg_name].default
         if arg_name.endswith("_"):
             arg_name = f"{arg_name[:-1]}\\_"
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -54,7 +54,7 @@ class A:
         return type(self)
 
     class Inner:
-        pass
+        ...
 
 
 class B(Generic[T]):
@@ -63,15 +63,15 @@ class B(Generic[T]):
 
 
 class C(B[str]):
-    pass
+    ...
 
 
 class D(typing_extensions.Protocol):
-    pass
+    ...
 
 
 class E(typing_extensions.Protocol[T]):  # type: ignore #  Invariant type variable "T" used in protocol where covariant
-    pass
+    ...
 
 
 class Slotted:
@@ -79,16 +79,16 @@ class Slotted:
 
 
 class Metaclass(type):
-    pass
+    ...
 
 
 class HintedMethods:
     @classmethod
-    def clsmethod(cls: type[T]) -> T:
-        pass
+    def from_magic(cls: type[T]) -> T:
+        ...
 
     def method(self: T) -> T:
-        pass
+        ...
 
 
 PY310_PLUS = sys.version_info >= (3, 10)
@@ -682,13 +682,13 @@ def test_normalize_source_lines_async_def() -> None:
     source = """
     async def async_function():
         class InnerClass:
-            def __init__(self): pass
+            def __init__(self): ...
     """
 
     expected = """
     async def async_function():
         class InnerClass:
-            def __init__(self): pass
+            def __init__(self): ...
     """
 
     assert normalize_source_lines(dedent(source)) == dedent(expected)
@@ -708,7 +708,7 @@ def test_normalize_source_lines_def_starting_decorator_parameter() -> None:
         ),
     )
     def __init__(bound_args):  # noqa: N805
-        pass
+        ...
     """
 
     expected = """
@@ -724,7 +724,7 @@ def test_normalize_source_lines_def_starting_decorator_parameter() -> None:
         ),
     )
     def __init__(bound_args):  # noqa: N805
-        pass
+        ...
     """
 
     assert normalize_source_lines(dedent(source)) == dedent(expected)
@@ -739,7 +739,7 @@ def test_default_no_signature(obj: Any) -> None:
     assert lines == []
 
 
-@pytest.mark.parametrize("method", [HintedMethods.clsmethod, HintedMethods().method])
+@pytest.mark.parametrize("method", [HintedMethods.from_magic, HintedMethods().method])
 def test_bound_class_method(method: FunctionType) -> None:
     config = create_autospec(
         Config,

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -84,7 +84,7 @@ class Metaclass(type):
 
 class HintedMethods:
     @classmethod
-    def clsmethod(cls: Type[T]) -> T:
+    def clsmethod(cls: type[T]) -> T:
         pass
 
     def method(self: T) -> T:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -740,11 +740,14 @@ def test_default_no_signature(obj: Any) -> None:
 
 
 @pytest.mark.parametrize("method", [HintedMethods.clsmethod, HintedMethods().method])
-@pytest.mark.sphinx("text", testroot="dummy")
-def test_bound_classmethod(app: SphinxTestApp, method: FunctionType) -> None:
-    # Make sure that processing bound methods with a typehint on self/cls don't
-    # raise an error because it doesn't appear in the inspect signature
-
-    # Raises KeyError('cls') on v1.14.0
+def test_bound_class_method(method: FunctionType) -> None:
+    config = create_autospec(
+        Config,
+        typehints_fully_qualified=False,
+        simplify_optional_unions=False,
+        typehints_document_rtype=False,
+        always_document_param_types=True,
+        typehints_defaults=True,
+    )
+    app: Sphinx = create_autospec(Sphinx, config=config)
     process_docstring(app, "class", method.__qualname__, method, None, [])
-    app.build()

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -2,7 +2,6 @@ ast3
 autodoc
 autouse
 backfill
-clsmethod
 contravariant
 cpython
 dedent

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -2,6 +2,7 @@ ast3
 autodoc
 autouse
 backfill
+clsmethod
 contravariant
 cpython
 dedent


### PR DESCRIPTION
https://github.com/tox-dev/sphinx-autodoc-typehints/commit/8dc8d94912431fa79a13f39d7570637244ac1a01 introduced an issue where a bound method with a type hint on the first argument would raise a KeyError looking up the default because that argument isn't present in the signature. This PR simply ignores those parameters.