### PR TITLE
Prevents reaching inner blocks that contains `if TYPE_CHECKING`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## WIP
+
+- Prevents reaching inner blocks that contains `if TYPE_CHECKING`
+
 ## 1.15.2
 
 - Log a warning instead of crashing when a type guard import fails to resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## WIP
+## 1.15.3
 
 - Prevents reaching inner blocks that contains `if TYPE_CHECKING`
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -271,7 +271,7 @@ def get_all_type_hints(obj: Any, name: str) -> dict[str, Any]:
     return _get_type_hint(name, obj)
 
 
-_TYPE_GUARD_IMPORT_RE = re.compile(r"if (typing.)?TYPE_CHECKING:[^\n]*([\s\S]*?)(?=\n\S)")
+_TYPE_GUARD_IMPORT_RE = re.compile(r"\nif (typing.)?TYPE_CHECKING:[^\n]*([\s\S]*?)(?=\n\S)")
 _TYPE_GUARD_IMPORTS_RESOLVED = set()
 
 

--- a/tests/roots/test-resolve-typing-guard/demo_typing_guard.py
+++ b/tests/roots/test-resolve-typing-guard/demo_typing_guard.py
@@ -29,6 +29,15 @@ def a(f: Decimal, s: AnyStr) -> Sequence[AnyStr | Decimal]:
     return [f, s]
 
 
+class SomeClass:
+    """This class do something."""
+
+    if TYPE_CHECKING:  # Classes doesn't have `__globals__` attribute
+
+        def __getattr__(self, item: str):  # noqa: U100
+            """This method do something."""
+
+
 __all__ = [
     "a",
     "ValueError",


### PR DESCRIPTION
Hi, thanks for your work on this plugin! We're having some problems with [returns](https://github.com/dry-python/returns) because we use type guards inside some classes like [here](https://github.com/dry-python/returns/blob/master/returns/primitives/hkt.py#L92) which leads in some warnings while building sphinx broking our builds:

```text
WARNING: Failed guarded type import with AttributeError('__globals__')
```

This PR fixes that issue, basically when a class object doesn't have the `__globals__` attribute so we basically can call `exec` without the globals if the given object doesn't have the mentioned attribute.