### PR TITLE
Add `typehints_use_rtype` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ The following configuration options are accepted:
   `True`, add stub documentation for undocumented parameters to be able to add type info.
 - `typehints_document_rtype` (default: `True`): If `False`, never add an `:rtype:` directive. If `True`, add the
   `:rtype:` directive if no existing `:rtype:` is found.
+- `typehints_use_rtype` (default: `True`):
+  Controls behavior when `typehints_document_rtype` is set to `True`.
+  If `True`, document return type in the `:rtype:` directive.
+  If `False`, document return type as part of the `:return:` directive, if present, otherwise fall back to useing `:rtype:`.
+  Use in conjunction with [napoleon_use_rtype](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#confval-napoleon_use_rtype) to avoid generation of duplicate or redundant return type information.
 - `typehints_defaults` (default: `None`): If `None`, defaults are not added. Otherwise adds a default annotation:
 
   - `'comma'` adds it after the type, changing Sphinx’ default look to “**param** (_int_, default: `1`) -- text”.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following configuration options are accepted:
 - `typehints_use_rtype` (default: `True`):
   Controls behavior when `typehints_document_rtype` is set to `True`.
   If `True`, document return type in the `:rtype:` directive.
-  If `False`, document return type as part of the `:return:` directive, if present, otherwise fall back to useing `:rtype:`.
+  If `False`, document return type as part of the `:return:` directive, if present, otherwise fall back to using `:rtype:`.
   Use in conjunction with [napoleon_use_rtype](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#confval-napoleon_use_rtype) to avoid generation of duplicate or redundant return type information.
 - `typehints_defaults` (default: `None`): If `None`, defaults are not added. Otherwise adds a default annotation:
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -570,8 +570,8 @@ def _inject_types_to_docstring(
             if app.config.typehints_use_rtype or insert_index == len(lines):
                 lines.insert(insert_index, f":rtype: {formatted_annotation}")
             else:
-                s = lines[insert_index]
-                lines[insert_index] = f":return: {formatted_annotation} --{s[s.find(' '):]}"
+                line = lines[insert_index]
+                lines[insert_index] = f":return: {formatted_annotation} --{line[line.find(' '):]}"
 
 
 def validate_config(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:  # noqa: U100

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -556,8 +556,6 @@ def _inject_types_to_docstring(
                 insert_index = None
                 break
             elif line.startswith(":return:") or line.startswith(":returns:"):
-                # This is brittle, I have not found information on how standard the use of " -- " to
-                # separate type from description is.
                 if " -- " in line and not app.config.typehints_use_rtype:
                     insert_index = None
                     break

--- a/tests/roots/test-dummy/dummy_module_simple_no_use_rtype.py
+++ b/tests/roots/test-dummy/dummy_module_simple_no_use_rtype.py
@@ -17,6 +17,16 @@ def function_returns_with_type(x: bool, y: int = 1) -> str:  # noqa: U100
     """
 
 
+def function_returns_with_compound_type(x: bool, y: int = 1) -> str:  # noqa: U100
+    """
+    Function docstring.
+
+    :param x: foo
+    :param y: bar
+    :returns: Union[str, int] -- A string or int
+    """
+
+
 def function_returns_without_type(x: bool, y: int = 1) -> str:  # noqa: U100
     """
     Function docstring.

--- a/tests/roots/test-dummy/dummy_module_simple_no_use_rtype.py
+++ b/tests/roots/test-dummy/dummy_module_simple_no_use_rtype.py
@@ -1,0 +1,25 @@
+def function_no_returns(x: bool, y: int = 1) -> str:  # noqa: U100
+    """
+    Function docstring.
+
+    :param x: foo
+    :param y: bar
+    """
+
+def function_returns_with_type(x: bool, y: int = 1) -> str:  # noqa: U100
+    """
+    Function docstring.
+
+    :param x: foo
+    :param y: bar
+    :returns: *CustomType* -- A string
+    """
+
+def function_returns_without_type(x: bool, y: int = 1) -> str:  # noqa: U100
+    """
+    Function docstring.
+
+    :param x: foo
+    :param y: bar
+    :returns: A string
+    """

--- a/tests/roots/test-dummy/dummy_module_simple_no_use_rtype.py
+++ b/tests/roots/test-dummy/dummy_module_simple_no_use_rtype.py
@@ -6,6 +6,7 @@ def function_no_returns(x: bool, y: int = 1) -> str:  # noqa: U100
     :param y: bar
     """
 
+
 def function_returns_with_type(x: bool, y: int = 1) -> str:  # noqa: U100
     """
     Function docstring.
@@ -14,6 +15,7 @@ def function_returns_with_type(x: bool, y: int = 1) -> str:  # noqa: U100
     :param y: bar
     :returns: *CustomType* -- A string
     """
+
 
 def function_returns_without_type(x: bool, y: int = 1) -> str:  # noqa: U100
     """

--- a/tests/roots/test-dummy/simple_no_use_rtype.rst
+++ b/tests/roots/test-dummy/simple_no_use_rtype.rst
@@ -3,4 +3,5 @@ Simple Module
 
 .. autofunction:: dummy_module_simple_no_use_rtype.function_no_returns
 .. autofunction:: dummy_module_simple_no_use_rtype.function_returns_with_type
+.. autofunction:: dummy_module_simple_no_use_rtype.function_returns_with_compound_type
 .. autofunction:: dummy_module_simple_no_use_rtype.function_returns_without_type

--- a/tests/roots/test-dummy/simple_no_use_rtype.rst
+++ b/tests/roots/test-dummy/simple_no_use_rtype.rst
@@ -1,0 +1,6 @@
+Simple Module
+=============
+
+.. autofunction:: dummy_module_simple_no_use_rtype.function_no_returns
+.. autofunction:: dummy_module_simple_no_use_rtype.function_returns_with_type
+.. autofunction:: dummy_module_simple_no_use_rtype.function_returns_without_type

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -916,3 +916,56 @@ def test_no_source_code_type_guard() -> None:
     from csv import Error
 
     _resolve_type_guarded_imports(Error)
+
+
+@pytest.mark.sphinx("text", testroot="dummy")
+@patch("sphinx.writers.text.MAXWIDTH", 2000)
+def test_sphinx_output_formatter_no_use_rtype(app: SphinxTestApp, status: StringIO) -> None:
+    set_python_path()
+    app.config.master_doc = "simple_no_use_rtype"  # type: ignore # create flag
+    app.config.typehints_use_rtype = False
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    text_path = pathlib.Path(app.srcdir) / "_build" / "text" / "simple_no_use_rtype.txt"
+    text_contents = text_path.read_text().replace("–", "--")
+    expected_contents = f"""\
+    Simple Module
+    *************
+
+    dummy_module_simple_no_use_rtype.function_no_returns(x, y=1)
+
+       Function docstring.
+
+       Parameters:
+          * **x** ("bool") -- foo
+
+          * **y** ("int") -- bar
+
+       Return type:
+          "str"
+
+    dummy_module_simple_no_use_rtype.function_returns_with_type(x, y=1)
+
+       Function docstring.
+
+       Parameters:
+          * **x** ("bool") -- foo
+
+          * **y** ("int") -- bar
+
+       Returns:
+          *CustomType* -- A string
+
+    dummy_module_simple_no_use_rtype.function_returns_without_type(x, y=1)
+
+       Function docstring.
+
+       Parameters:
+          * **x** ("bool") -- foo
+
+          * **y** ("int") -- bar
+
+       Returns:
+          "str" -- A string
+    """
+    assert text_contents == dedent(expected_contents)

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -923,12 +923,12 @@ def test_no_source_code_type_guard() -> None:
 def test_sphinx_output_formatter_no_use_rtype(app: SphinxTestApp, status: StringIO) -> None:
     set_python_path()
     app.config.master_doc = "simple_no_use_rtype"  # type: ignore # create flag
-    app.config.typehints_use_rtype = False
+    app.config.typehints_use_rtype = False  # type: ignore
     app.build()
     assert "build succeeded" in status.getvalue()
     text_path = pathlib.Path(app.srcdir) / "_build" / "text" / "simple_no_use_rtype.txt"
     text_contents = text_path.read_text().replace("–", "--")
-    expected_contents = f"""\
+    expected_contents = """\
     Simple Module
     *************
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -956,6 +956,18 @@ def test_sphinx_output_formatter_no_use_rtype(app: SphinxTestApp, status: String
        Returns:
           *CustomType* -- A string
 
+    dummy_module_simple_no_use_rtype.function_returns_with_compound_type(x, y=1)
+
+       Function docstring.
+
+       Parameters:
+          * **x** ("bool") -- foo
+
+          * **y** ("int") -- bar
+
+       Returns:
+          Union[str, int] -- A string or int
+
     dummy_module_simple_no_use_rtype.function_returns_without_type(x, y=1)
 
        Function docstring.

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ description = run type check on code base
 setenv =
     {tty:MYPY_FORCE_COLOR = 1}
 deps =
-    mypy==0.930
+    mypy==0.931
     types-docutils
 commands =
     mypy --python-version 3.10 src


### PR DESCRIPTION
This fixes an interoperability issue with `sphinx.ext.napoleon`. See issue and code for details.

There is a string-matching aspect to this (see comment in code) that I am not happy with. Is there a better solution? Note that this potentially brittle behavior would only occur if this new option is explicitly disabled, i.e., it should not break existing behavior.

Fixes #217.