### PR TITLE
Add support for recursive type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.19.1
+
+- Fix bug for recursive type alias.
+
 ## 1.19.0
 
 - Support for CPython 3.11, no longer adds `Optional` when the argument is default per

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -5,7 +5,6 @@ import re
 import sys
 import textwrap
 from ast import FunctionDef, Module, stmt
-from typing import _eval_type  # type: ignore # no import defined in stubs
 from typing import Any, AnyStr, Callable, ForwardRef, NewType, TypeVar, get_type_hints
 
 from sphinx.application import Sphinx
@@ -120,8 +119,7 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
 
     # Special cases
     if isinstance(annotation, ForwardRef):
-        value = _resolve_forward_ref(annotation, config)
-        return format_annotation(value, config)
+        return annotation.__forward_arg__
     if annotation is None or annotation is type(None):  # noqa: E721
         return ":py:obj:`None`"
     if annotation is Ellipsis:
@@ -192,17 +190,6 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
         formatted_args = args_format.format(", ".join(fmt))
 
     result = f":py:{role}:`{prefix}{full_name}`{formatted_args}"
-    return result
-
-
-def _resolve_forward_ref(annotation: ForwardRef, config: Config) -> Any:
-    raw, base_globals = annotation.__forward_arg__, config._annotation_globals
-    params = {"is_class": True} if (3, 10) > sys.version_info >= (3, 9, 8) or sys.version_info >= (3, 10, 1) else {}
-    value = ForwardRef(raw, is_argument=False, **params)
-    try:
-        result = _eval_type(value, base_globals, None)
-    except NameError:
-        result = raw  # fallback to the value itself as string
     return result
 
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -15,6 +15,7 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    List,
     Mapping,
     Match,
     NewType,
@@ -54,6 +55,11 @@ Y = TypeVar("Y", bound=str)
 Z = TypeVar("Z", bound="A")
 S = TypeVar("S", bound="miss")  # type: ignore # miss not defined on purpose # noqa: F821
 W = NewType("W", str)
+
+RecList = Union[int, List["RecList"]]
+
+MutualRecA = Union[bool, List["MutualRecB"]]
+MutualRecB = Union[str, List["MutualRecA"]]
 
 
 class A:
@@ -228,7 +234,7 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
         (V, ":py:class:`~typing.TypeVar`\\(``V``, contravariant=True)"),
         (X, ":py:class:`~typing.TypeVar`\\(``X``, :py:class:`str`, :py:class:`int`)"),
         (Y, ":py:class:`~typing.TypeVar`\\(``Y``, bound= :py:class:`str`)"),
-        (Z, ":py:class:`~typing.TypeVar`\\(``Z``, bound= :py:class:`~test_sphinx_autodoc_typehints.A`)"),
+        (Z, ":py:class:`~typing.TypeVar`\\(``Z``, bound= A)"),
         (S, ":py:class:`~typing.TypeVar`\\(``S``, bound= miss)"),
         # ## These test for correct internal tuple rendering, even if not all are valid Tuple types
         # Zero-length tuple remains
@@ -278,6 +284,14 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
                 ":py:class:`~nptyping.base_meta_classes.NDArray`\\[:py:class:`~nptyping.base_meta_classes.Shape`\\[3, "
                 "...], :py:class:`~numpy.float64`]"
             ),
+        ),
+        (
+            RecList,
+            (":py:data:`~typing.Union`\\[:py:class:`int`, :py:class:`~typing.List`\\[RecList]]"),
+        ),
+        (
+            MutualRecA,
+            (":py:data:`~typing.Union`\\[:py:class:`bool`, :py:class:`~typing.List`\\[MutualRecB]]"),
         ),
     ],
 )

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -56,10 +56,11 @@ Z = TypeVar("Z", bound="A")
 S = TypeVar("S", bound="miss")  # type: ignore # miss not defined on purpose # noqa: F821
 W = NewType("W", str)
 
-RecList = Union[int, List["RecList"]]
-
-MutualRecA = Union[bool, List["MutualRecB"]]
-MutualRecB = Union[str, List["MutualRecA"]]
+# Mypy does not support recursive type aliases, but
+# other type checkers do.
+RecList = Union[int, List["RecList"]]  # type: ignore
+MutualRecA = Union[bool, List["MutualRecB"]]  # type: ignore
+MutualRecB = Union[str, List["MutualRecA"]]  # type: ignore
 
 
 class A:


### PR DESCRIPTION
Closes #223. This is simple approach that uses string of forward reference and avoids needing to evaluate recursive/mutually recursive type aliases.

I've added two test cases that use recursive aliases and previously would crash. I've also been using this fork for a while in company internal codebase and it's worked well for our recursive annotations.