### PR TITLE
only convert role for pydata annotations if module is typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.19.2
+
+- Fix incorrect domain used for collections.abc.Callable.
+
 ## 1.19.1
 
 - Fix bug for recursive type alias.

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -142,7 +142,10 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
     full_name = f"{module}.{class_name}" if module != "builtins" else class_name
     fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
     prefix = "" if fully_qualified or full_name == class_name else "~"
-    role = "data" if class_name in _PYDATA_ANNOTATIONS else "class"
+    if module == "typing" and class_name in _PYDATA_ANNOTATIONS:
+        role = "data"
+    else:
+        role = "class"
     args_format = "\\[{}]"
     formatted_args: str | None = ""
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc
 import pathlib
 import re
 import sys
@@ -153,6 +154,7 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
         (int, ":py:class:`int`"),
         (type(None), ":py:obj:`None`"),
         (type, ":py:class:`type`"),
+        (collections.abc.Callable, ":py:class:`~collections.abc.Callable`"),
         (Type, ":py:class:`~typing.Type`"),
         (Type[A], ":py:class:`~typing.Type`\\[:py:class:`~%s.A`]" % __name__),
         (Any, ":py:data:`~typing.Any`"),


### PR DESCRIPTION
The names may have an origin that's not typing, causing an incorrect
role to be applied to them

fixes: #237