### PR TITLE
allow starred args and kwargs in docstring params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use hatchling instead of setuptools
 - Add support for typing.ParamSpec
+- Allow star prefixes for parameter names in docstring
 
 ## 1.19.2
 

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -126,6 +126,15 @@ def function(x: bool, y: int, z_: typing.Optional[str] = None) -> str:  # noqa: 
     """
 
 
+def function_with_starred_documentation_param_names(*args: int, **kwargs: str):  # noqa: U100
+    r"""
+    Function docstring.
+
+    :param \*args: foo
+    :param \**kwargs: bar
+    """
+
+
 def function_with_escaped_default(x: str = "\b"):  # noqa: U100
     """
     Function docstring.

--- a/tests/roots/test-dummy/index.rst
+++ b/tests/roots/test-dummy/index.rst
@@ -19,6 +19,8 @@ Dummy Module
 
 .. autofunction:: dummy_module.function_with_typehint_comment
 
+.. autofunction:: dummy_module.function_with_starred_documentation_param_names
+
 .. autoclass:: dummy_module.ClassWithTypehints
    :members:
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -619,6 +619,15 @@ def test_sphinx_output(
            Return type:
               "None"
 
+        dummy_module.function_with_starred_documentation_param_names(*args, **kwargs)
+
+           Function docstring.
+
+           Parameters:
+              * ***args** ("int") -- foo
+
+              * ****kwargs** ("str") -- bar
+
         class dummy_module.ClassWithTypehints(x)
 
            Class docstring.


### PR DESCRIPTION
closes: #253 