### PR TITLE
Add support for paramspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.20
 
 - Use hatchling instead of setuptools
+- Add support for typing.ParamSpec
 
 ## 1.19.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ optional-dependencies.testing = [
   "sphobjinv>=2.2.2",
   "typing-extensions>=4.3",
 ]
-optional-dependencies.type_comment = ['typed-ast>=1.5.4; python_version < "3.8"']
+optional-dependencies.type-comment = ['typed-ast>=1.5.4; python_version < "3.8"']
 dynamic = ["version"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -64,7 +64,7 @@ def get_annotation_class_name(annotation: Any, module: str) -> str:
             return origin._name  # type: ignore # deduced Any
 
     annotation_cls = annotation if inspect.isclass(annotation) else type(annotation)
-    return annotation_cls.__qualname__.lstrip("_")  # type: ignore # deduced Any
+    return annotation_cls.__qualname__.lstrip("_")
 
 
 def get_annotation_args(annotation: Any, module: str, class_name: str) -> tuple[Any, ...]:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -57,9 +57,9 @@ Z = TypeVar("Z", bound="A")
 S = TypeVar("S", bound="miss")  # type: ignore # miss not defined on purpose # noqa: F821
 W = NewType("W", str)
 P = typing_extensions.ParamSpec("P")
-P_co = typing_extensions.ParamSpec("P_co", covariant=True)
-P_contra = typing_extensions.ParamSpec("P_contra", contravariant=True)
-P_bound = typing_extensions.ParamSpec("P_bound", bound=str)
+P_co = typing_extensions.ParamSpec("P_co", covariant=True)  # type: ignore
+P_contra = typing_extensions.ParamSpec("P_contra", contravariant=True)  # type: ignore
+P_bound = typing_extensions.ParamSpec("P_bound", bound=str)  # type: ignore
 
 # Mypy does not support recursive type aliases, but
 # other type checkers do.

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -56,6 +56,10 @@ Y = TypeVar("Y", bound=str)
 Z = TypeVar("Z", bound="A")
 S = TypeVar("S", bound="miss")  # type: ignore # miss not defined on purpose # noqa: F821
 W = NewType("W", str)
+P = typing_extensions.ParamSpec("P")
+P_co = typing_extensions.ParamSpec("P_co", covariant=True)
+P_contra = typing_extensions.ParamSpec("P_contra", contravariant=True)
+P_bound = typing_extensions.ParamSpec("P_bound", bound=str)
 
 # Mypy does not support recursive type aliases, but
 # other type checkers do.
@@ -239,6 +243,11 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
         (Y, ":py:class:`~typing.TypeVar`\\(``Y``, bound= :py:class:`str`)"),
         (Z, ":py:class:`~typing.TypeVar`\\(``Z``, bound= A)"),
         (S, ":py:class:`~typing.TypeVar`\\(``S``, bound= miss)"),
+        # ParamSpec should behave like TypeVar, except for missing constraints
+        (P, ":py:class:`~typing.ParamSpec`\\(``P``)"),
+        (P_co, ":py:class:`~typing.ParamSpec`\\(``P_co``, covariant=True)"),
+        (P_contra, ":py:class:`~typing.ParamSpec`\\(``P_contra``, contravariant=True)"),
+        (P_bound, ":py:class:`~typing.ParamSpec`\\(``P_bound``, bound= :py:class:`str`)"),
         # ## These test for correct internal tuple rendering, even if not all are valid Tuple types
         # Zero-length tuple remains
         (Tuple[()], ":py:data:`~typing.Tuple`"),

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     COVERAGE_FILE = {toxworkdir}{/}.coverage.{envname}
 extras =
     testing
-    type_comments
+    type-comment
 commands =
     pytest {tty:--color=yes} {posargs: \
       --junitxml {toxworkdir}{/}junit.{envname}.xml --cov {envsitepackagesdir}{/}sphinx_autodoc_typehints --cov {toxinidir}{/}tests \


### PR DESCRIPTION
Adds support for ParamSpec, to keep compat I've decided to only check the name as typing_extensions is not a normal dep, and someone else using the name seems unlikely, though a check for some attribute could be added if necessary