### PR TITLE
Added options to retain original typehints in signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ dist
 .*_cache
 /src/sphinx_autodoc_typehints/version.py
 venv*
-.idea*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .*_cache
 /src/sphinx_autodoc_typehints/version.py
 venv*
+.idea*

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ The following configuration options are accepted:
   it will **always** be displayed as Optional!
 - `typehints_formatter` (default: `None`): If set to a function, this function will be called with `annotation` as first
   argument and `sphinx.config.Config` argument second. The function is expected to return a string with reStructuredText
-  code or `None` to fall back to the default formatter.
+  code or `None` to fall back to the default formatter. 
+- `typehints_use_signature` (default: `False`): If `True`, typehints for parameters in the signature are shown.
+- `typehints_use_signature_return` (default: `False`): If `True`, return annotations in the signature are shown.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The following configuration options are accepted:
   it will **always** be displayed as Optional!
 - `typehints_formatter` (default: `None`): If set to a function, this function will be called with `annotation` as first
   argument and `sphinx.config.Config` argument second. The function is expected to return a string with reStructuredText
-  code or `None` to fall back to the default formatter. 
+  code or `None` to fall back to the default formatter.
 - `typehints_use_signature` (default: `False`): If `True`, typehints for parameters in the signature are shown.
 - `typehints_use_signature_return` (default: `False`): If `True`, return annotations in the signature are shown.
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -277,7 +277,11 @@ def process_signature(
             if not isinstance(method_object, (classmethod, staticmethod)):
                 start = 1
 
-    sph_signature = sph_signature.replace(parameters=parameters[start:], return_annotation=inspect.Signature.empty)
+    if not app.config.typehints_use_signature:
+        sph_signature = sph_signature.replace(parameters=parameters[start:])    
+    if not app.config.typehints_use_signature_return:
+        sph_signature = sph_signature.replace(return_annotation=inspect.Signature.empty)
+        
     return stringify_signature(sph_signature).replace("\\", "\\\\"), None
 
 
@@ -634,6 +638,8 @@ def setup(app: Sphinx) -> dict[str, bool]:
     app.add_config_value("typehints_defaults", None, "env")
     app.add_config_value("simplify_optional_unions", True, "env")
     app.add_config_value("typehints_formatter", None, "env")
+    app.add_config_value("typehints_use_signature", False, "env")
+    app.add_config_value("typehints_use_signature_return", False, "env")
     app.connect("env-before-read-docs", validate_config)  # config may be changed after “config-inited” event
     app.connect("autodoc-process-signature", process_signature)
     app.connect("autodoc-process-docstring", process_docstring)

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -254,7 +254,11 @@ def process_signature(
 
     obj = inspect.unwrap(obj)
     sph_signature = sphinx_signature(obj)
-    parameters = [param.replace(annotation=inspect.Parameter.empty) for param in sph_signature.parameters.values()]
+
+    if app.config.typehints_use_signature:
+        parameters = list(sph_signature.parameters.values())
+    else:
+        parameters = [param.replace(annotation=inspect.Parameter.empty) for param in sph_signature.parameters.values()]
 
     # if we have parameters we may need to delete first argument that's not documented, e.g. self
     start = 0
@@ -277,11 +281,10 @@ def process_signature(
             if not isinstance(method_object, (classmethod, staticmethod)):
                 start = 1
 
-    if not app.config.typehints_use_signature:
-        sph_signature = sph_signature.replace(parameters=parameters[start:])    
+    sph_signature = sph_signature.replace(parameters=parameters[start:])
     if not app.config.typehints_use_signature_return:
         sph_signature = sph_signature.replace(return_annotation=inspect.Signature.empty)
-        
+
     return stringify_signature(sph_signature).replace("\\", "\\\\"), None
 
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -1033,3 +1033,91 @@ def test_sphinx_output_formatter_no_use_rtype(app: SphinxTestApp, status: String
           "str" -- A string
     """
     assert text_contents == dedent(expected_contents)
+
+
+@pytest.mark.sphinx("text", testroot="dummy")
+@patch("sphinx.writers.text.MAXWIDTH", 2000)
+def test_sphinx_output_with_use_signature(app: SphinxTestApp, status: StringIO) -> None:
+    set_python_path()
+    app.config.master_doc = "simple"  # type: ignore # create flag
+    app.config.typehints_use_signature = True  # type: ignore
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    text_path = pathlib.Path(app.srcdir) / "_build" / "text" / "simple.txt"
+    text_contents = text_path.read_text().replace("–", "--")
+    expected_contents = """\
+    Simple Module
+    *************
+
+    dummy_module_simple.function(x: bool, y: int = 1)
+
+       Function docstring.
+
+       Parameters:
+          * **x** ("bool") -- foo
+
+          * **y** ("int") -- bar
+
+       Return type:
+          "str"
+    """
+    assert text_contents == dedent(expected_contents)
+
+
+@pytest.mark.sphinx("text", testroot="dummy")
+@patch("sphinx.writers.text.MAXWIDTH", 2000)
+def test_sphinx_output_with_use_signature_return(app: SphinxTestApp, status: StringIO) -> None:
+    set_python_path()
+    app.config.master_doc = "simple"  # type: ignore # create flag
+    app.config.typehints_use_signature_return = True  # type: ignore
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    text_path = pathlib.Path(app.srcdir) / "_build" / "text" / "simple.txt"
+    text_contents = text_path.read_text().replace("–", "--")
+    expected_contents = """\
+    Simple Module
+    *************
+
+    dummy_module_simple.function(x, y=1) -> str
+
+       Function docstring.
+
+       Parameters:
+          * **x** ("bool") -- foo
+
+          * **y** ("int") -- bar
+
+       Return type:
+          "str"
+    """
+    assert text_contents == dedent(expected_contents)
+
+
+@pytest.mark.sphinx("text", testroot="dummy")
+@patch("sphinx.writers.text.MAXWIDTH", 2000)
+def test_sphinx_output_with_use_signature_and_return(app: SphinxTestApp, status: StringIO) -> None:
+    set_python_path()
+    app.config.master_doc = "simple"  # type: ignore # create flag
+    app.config.typehints_use_signature = True  # type: ignore
+    app.config.typehints_use_signature_return = True  # type: ignore
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    text_path = pathlib.Path(app.srcdir) / "_build" / "text" / "simple.txt"
+    text_contents = text_path.read_text().replace("–", "--")
+    expected_contents = """\
+    Simple Module
+    *************
+
+    dummy_module_simple.function(x: bool, y: int = 1) -> str
+
+       Function docstring.
+
+       Parameters:
+          * **x** ("bool") -- foo
+
+          * **y** ("int") -- bar
+
+       Return type:
+          "str"
+    """
+    assert text_contents == dedent(expected_contents)


### PR DESCRIPTION
I was using this library and noticed that there was no existing way to retain the typehints automatically generated by autodoc in function/class/method signatures. I quite liked the way that return types are annotated with the -> in signatures and wanted to preserve those while using autodoc-typehints.

This pull request adds 2 simple options that **do not alter the behaviour of anyone already using typehints**:

1. `typehints_use_signature` (`False` by default)
2. `typehints_use_signature_return` (`False` by default)

By setting these, the `sph_signature.replace()` commands in `process_signature()` can be altered

With default options:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/67759015/210525359-4398bbf4-fee7-48ab-bd5c-c9b360ca6081.png">

With the new options set to `True`:
<img width="386" alt="image" src="https://user-images.githubusercontent.com/67759015/210525788-ed48433d-df97-42f5-8c60-5899c65b62a9.png">
