### PR TITLE
Set role to data when creating an Optional from `| None`

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -168,11 +168,13 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
     elif full_name in ("typing.Union", "types.UnionType") and type(None) in args:
         if len(args) == 2:
             full_name = "typing.Optional"
+            role = "data"
             args = tuple(x for x in args if x is not type(None))  # noqa: E721
         else:
             simplify_optional_unions: bool = getattr(config, "simplify_optional_unions", True)
             if not simplify_optional_unions:
                 full_name = "typing.Optional"
+                role = "data"
                 args_format = f"\\[:py:data:`{prefix}typing.Union`\\[{{}}]]"
                 args = tuple(x for x in args if x is not type(None))  # noqa: E721
     elif full_name == "typing.Callable" and args and args[0] is not ...:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -203,6 +203,7 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
             ),
         ),
         (Optional[str], ":py:data:`~typing.Optional`\\[:py:class:`str`]"),
+        (Union[str, None], ":py:data:`~typing.Optional`\\[:py:class:`str`]"),
         (
             Optional[Union[str, bool]],
             ":py:data:`~typing.Union`\\[:py:class:`str`, " ":py:class:`bool`, :py:obj:`None`]",


### PR DESCRIPTION
This is not super important, but when converting `| None` to `Optional` the code sets the role incorrectly to `class` and so generates dead links.