### PR TITLE
Put Literal args in code blocks

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -179,7 +179,9 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
         fmt = [format_annotation(arg, config) for arg in args]
         formatted_args = f"\\[\\[{', '.join(fmt[:-1])}], {fmt[-1]}]"
     elif full_name == "typing.Literal":
-        formatted_args = f"\\[{', '.join(repr(arg) for arg in args)}]"
+        formatted_args = "\\[{}]".format(
+            ", ".join(f"``{arg!r}``" for arg in args)
+        )
     elif full_name == "types.UnionType":
         return " | ".join([format_annotation(arg, config) for arg in args])
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -179,9 +179,7 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
         fmt = [format_annotation(arg, config) for arg in args]
         formatted_args = f"\\[\\[{', '.join(fmt[:-1])}], {fmt[-1]}]"
     elif full_name == "typing.Literal":
-        formatted_args = "\\[{}]".format(
-            ", ".join(f"``{arg!r}``" for arg in args)
-        )
+        formatted_args = "\\[{}]".format(", ".join(f"``{arg!r}``" for arg in args))
     elif full_name == "types.UnionType":
         return " | ".join([format_annotation(arg, config) for arg in args])
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -359,7 +359,7 @@ def test_format_annotation(inv: Inventory, annotation: Any, expected_result: str
     [
         ("ClassVar", int, ":py:data:`~typing.ClassVar`\\[:py:class:`int`]"),
         ("NoReturn", None, ":py:data:`~typing.NoReturn`"),
-        ("Literal", ("a", 1), ":py:data:`~typing.Literal`\\['a', 1]"),
+        ("Literal", ("a", 1), ":py:data:`~typing.Literal`\\[``'a'``, ``1``]"),
         ("Type", None, ":py:class:`~typing.Type`"),
         ("Type", (A,), f":py:class:`~typing.Type`\\[:py:class:`~{__name__}.A`]"),
     ],


### PR DESCRIPTION
This is a pretty minor change, but I think it improves the visual consistency of the types.

#### Before:
![Screenshot from 2023-01-13 21-40-15](https://user-images.githubusercontent.com/8739626/212457866-1fb7600e-d487-4793-8505-73e36f73c2c8.png)

#### After:
![Screenshot from 2023-01-13 21-40-23](https://user-images.githubusercontent.com/8739626/212457874-798f0522-120c-434a-95c7-55e18cbc3494.png)

