### PR TITLE
Handle collections.abc.Callable as well as typing.Callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.20.2
+
+- Fix Optional role to be data.
+
 ## 1.20.1
 
 - Fixed default options not displaying for parameters without type hints.

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -177,7 +177,7 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
                 role = "data"
                 args_format = f"\\[:py:data:`{prefix}typing.Union`\\[{{}}]]"
                 args = tuple(x for x in args if x is not type(None))  # noqa: E721
-    elif full_name == "typing.Callable" and args and args[0] is not ...:
+    elif full_name in ("typing.Callable", "collections.abc.Callable") and args and args[0] is not ...:
         fmt = [format_annotation(arg, config) for arg in args]
         formatted_args = f"\\[\\[{', '.join(fmt[:-1])}], {fmt[-1]}]"
     elif full_name == "typing.Literal":

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -112,21 +112,21 @@ class HintedMethods:
 PY310_PLUS = sys.version_info >= (3, 10)
 
 if sys.version_info >= (3, 9):
-    abcCallable = collections.abc.Callable
+    AbcCallable = collections.abc.Callable
 else:
     # Hacks to make it work the same in old versions.
-    # We could also set abcCallable = typing.Callable and xfail the tests that
-    # use in if not PY39_PLUS.
-    class MyGenericAlias(typing._VariadicGenericAlias, _root=True):
-        def __getitem__(self, params):
-            result = super().__getitem__(params)
+    # We could also set AbcCallable = typing.Callable and x fail the tests that
+    # use AbcCallable when in versions less than 3.9.
+    class MyGenericAlias(typing._VariadicGenericAlias, _root=True):  # noqa: SC200
+        def __getitem__(self, params):  # noqa: SC200
+            result = super().__getitem__(params)  # noqa: SC200
             # Make a copy so we don't change the name of a cached annotation
             result = result.copy_with(result.__args__)
             result.__module__ = "collections.abc"
             return result
 
-    abcCallable = MyGenericAlias(collections.abc.Callable, (), special=True)
-    abcCallable.__module__ = "collections.abc"
+    AbcCallable = MyGenericAlias(collections.abc.Callable, (), special=True)
+    AbcCallable.__module__ = "collections.abc"
 
 
 @pytest.mark.parametrize(
@@ -146,7 +146,7 @@ else:
         pytest.param(Callable[..., str], "typing", "Callable", (..., str), id="Callable_returntype"),
         pytest.param(Callable[[int, str], str], "typing", "Callable", (int, str, str), id="Callable_all_types"),
         pytest.param(
-            abcCallable[[int, str], str],
+            AbcCallable[[int, str], str],
             "collections.abc",
             "Callable",
             (int, str, str),
@@ -249,7 +249,7 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
             " :py:class:`~typing.TypeVar`\\(``T``)]",
         ),
         (
-            abcCallable[[int, str], bool],
+            AbcCallable[[int, str], bool],
             ":py:class:`~collections.abc.Callable`\\[\\[:py:class:`int`, " ":py:class:`str`], :py:class:`bool`]",
         ),
         (Pattern, ":py:class:`~typing.Pattern`"),

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -112,7 +112,7 @@ class HintedMethods:
 PY310_PLUS = sys.version_info >= (3, 10)
 
 if sys.version_info >= (3, 9):
-    AbcCallable = collections.abc.Callable
+    AbcCallable = collections.abc.Callable  # type: ignore[type-arg]
 else:
     # Hacks to make it work the same in old versions.
     # We could also set AbcCallable = typing.Callable and x fail the tests that
@@ -146,7 +146,7 @@ else:
         pytest.param(Callable[..., str], "typing", "Callable", (..., str), id="Callable_returntype"),
         pytest.param(Callable[[int, str], str], "typing", "Callable", (int, str, str), id="Callable_all_types"),
         pytest.param(
-            AbcCallable[[int, str], str],
+            AbcCallable[[int, str], str],  # type: ignore[misc]
             "collections.abc",
             "Callable",
             (int, str, str),
@@ -249,7 +249,7 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
             " :py:class:`~typing.TypeVar`\\(``T``)]",
         ),
         (
-            AbcCallable[[int, str], bool],
+            AbcCallable[[int, str], bool],  # type: ignore[misc]
             ":py:class:`~collections.abc.Callable`\\[\\[:py:class:`int`, " ":py:class:`str`], :py:class:`bool`]",
         ),
         (Pattern, ":py:class:`~typing.Pattern`"),

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -128,6 +128,7 @@ PY310_PLUS = sys.version_info >= (3, 10)
         pytest.param(Callable, "typing", "Callable", (), id="Callable"),
         pytest.param(Callable[..., str], "typing", "Callable", (..., str), id="Callable_returntype"),
         pytest.param(Callable[[int, str], str], "typing", "Callable", (int, str, str), id="Callable_all_types"),
+        pytest.param(collections.abc.Callable[[int, str], str], "collections.abc", "Callable", (int, str, str), id="collections.abc.Callable_all_types"),
         pytest.param(Pattern, "typing", "Pattern", (), id="Pattern"),
         pytest.param(Pattern[str], "typing", "Pattern", (str,), id="Pattern_parametrized"),
         pytest.param(Match, "typing", "Match", (), id="Match"),
@@ -223,6 +224,10 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
             Callable[[T], T],
             ":py:data:`~typing.Callable`\\[\\[:py:class:`~typing.TypeVar`\\(``T``)],"
             " :py:class:`~typing.TypeVar`\\(``T``)]",
+        ),
+        (
+            collections.abc.Callable[[int, str], bool],
+            ":py:class:`~collections.abc.Callable`\\[\\[:py:class:`int`, " ":py:class:`str`], :py:class:`bool`]",
         ),
         (Pattern, ":py:class:`~typing.Pattern`"),
         (Pattern[str], ":py:class:`~typing.Pattern`\\[:py:class:`str`]"),


### PR DESCRIPTION
typing.Callable is deprecated in favor of collections.abc.Callable since Python 3.9:
https://docs.python.org/3/library/typing.html?highlight=typing%20callable#typing.Callable

This fixes the rendering to look correct regardless of which `Callable` annotation you use.