### PR TITLE
If module is _io, use io instead

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -139,6 +139,9 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901 # t
     if module == "typing_extensions":
         module = "typing"
 
+    if module == "_io":
+        module = "io"
+
     full_name = f"{module}.{class_name}" if module != "builtins" else class_name
     fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
     prefix = "" if fully_qualified or full_name == class_name else "~"

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -180,6 +180,7 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
     [
         (str, ":py:class:`str`"),
         (int, ":py:class:`int`"),
+        (StringIO, ":py:class:`~io.StringIO`"),
         (type(None), ":py:obj:`None`"),
         (type, ":py:class:`type`"),
         (collections.abc.Callable, ":py:class:`~collections.abc.Callable`"),


### PR DESCRIPTION
Most of the io module is implemented in the private C extension module called _io. It would be friendly if Python set the module name to io to match the way it is documented but they don't.

I'm not sure how much it is desirable to add a bunch of module name redirects here. Also, perhaps it would be useful to have a configuration option that allows specifying more module redirects since reexporting classes is pretty common.