### PR TITLE
Handle types from types module

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -44,7 +44,7 @@ def get_annotation_module(annotation: Any) -> str:
     raise ValueError(f"Cannot determine the module of {annotation}")
 
 
-def _is_newtype(annotation: Any):
+def _is_newtype(annotation: Any) -> bool:
     if sys.version_info < (3, 10):
         return inspect.isfunction(annotation) and hasattr(annotation, "__supertype__")
     else:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -4,6 +4,7 @@ import collections.abc
 import pathlib
 import re
 import sys
+import types
 import typing
 from functools import cmp_to_key
 from io import StringIO
@@ -134,6 +135,10 @@ else:
     [
         pytest.param(str, "builtins", "str", (), id="str"),
         pytest.param(None, "builtins", "None", (), id="None"),
+        pytest.param(ModuleType, "types", "ModuleType", (), id="ModuleType"),
+        pytest.param(FunctionType, "types", "FunctionType", (), id="FunctionType"),
+        pytest.param(types.CodeType, "types", "CodeType", (), id="CodeType"),
+        pytest.param(types.CoroutineType, "types", "CoroutineType", (), id="CoroutineType"),
         pytest.param(Any, "typing", "Any", (), id="Any"),
         pytest.param(AnyStr, "typing", "AnyStr", (), id="AnyStr"),
         pytest.param(Dict, "typing", "Dict", (), id="Dict"),
@@ -170,9 +175,10 @@ else:
     ],
 )
 def test_parse_annotation(annotation: Any, module: str, class_name: str, args: tuple[Any, ...]) -> None:
-    assert get_annotation_module(annotation) == module
-    assert get_annotation_class_name(annotation, module) == class_name
-    assert get_annotation_args(annotation, module, class_name) == args
+    got_mod = get_annotation_module(annotation)
+    got_cls = get_annotation_class_name(annotation, module)
+    got_args = get_annotation_args(annotation, module, class_name)
+    assert (got_mod, got_cls, got_args) == (module, class_name, args)
 
 
 @pytest.mark.parametrize(
@@ -181,6 +187,8 @@ def test_parse_annotation(annotation: Any, module: str, class_name: str, args: t
         (str, ":py:class:`str`"),
         (int, ":py:class:`int`"),
         (StringIO, ":py:class:`~io.StringIO`"),
+        (FunctionType, ":py:class:`~types.FunctionType`"),
+        (ModuleType, ":py:class:`~types.ModuleType`"),
         (type(None), ":py:obj:`None`"),
         (type, ":py:class:`type`"),
         (collections.abc.Callable, ":py:class:`~collections.abc.Callable`"),

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -4,6 +4,7 @@ autouse
 backfill
 conf
 contravariant
+Coroutine
 cpython
 csv
 dedent
@@ -31,7 +32,9 @@ iterdir
 kwonlyargs
 libs
 metaclass
+ModuleType
 multiline
+newtype
 nptyping
 param
 parametrized


### PR DESCRIPTION
The `types` module has a bunch of things like `ModuleType`: `ModuleType.__module__` is
"builtins" and `ModuleType.__name__` is "module", but it should be referenced as `types.ModuleType`.

To deal with these, I made a dict of values exported from `types` to the export name. If an annotation
is in this dict, we use "types" as the module and the reported name as the name.

I also made a couple of nonfunctional changes: 
1. I think `_is_newtype` is more readable as a separate method so I factored it out.
2. `test_parse_annotation` displays more useful error messages if we assert two tuples are equal than if we make three sequential assertions -- this way we can see if more than one are wrong.