### PR TITLE
More robust determination of rtype location / fix issue 302

### DIFF
--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -395,3 +395,15 @@ def func_with_code_block() -> int:
 
     Here are a couple of examples of how to use this function.
     """
+
+
+def func_with_definition_list() -> int:
+    """Some text and then a definition list.
+
+    abc
+        x
+
+    xyz
+        something
+    """
+    # See https://github.com/tox-dev/sphinx-autodoc-typehints/issues/302

--- a/tests/roots/test-dummy/index.rst
+++ b/tests/roots/test-dummy/index.rst
@@ -55,3 +55,5 @@ Dummy Module
 .. autofunction:: dummy_module.empty_line_between_parameters
 
 .. autofunction:: dummy_module.func_with_code_block
+
+.. autofunction:: dummy_module.func_with_definition_list

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -880,6 +880,19 @@ def test_sphinx_output(
            -[ Examples ]-
 
            Here are a couple of examples of how to use this function.
+
+        dummy_module.func_with_definition_list()
+
+           Some text and then a definition list.
+
+           Return type:
+              "int"
+
+           abc
+              x
+
+           xyz
+              something
         """
         expected_contents = dedent(expected_contents).format(**format_args).replace("–", "--")
         assert text_contents == maybe_fix_py310(expected_contents)


### PR DESCRIPTION
Resolves #302.

This increases the robustness of the handling of the docutils tree. The docutils rst parser seems to have a bunch of bugs / shortcomings. The original problem was that several list types do not get their line number set. So to find the line number of a node, if the node itself has None as the line number, we descend through the first children of the node until we find one with a non-None line number.