### PR TITLE
Patch docutils rst parser to add line numbers to more nodes

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -678,7 +678,7 @@ def node_line_no(node: Node) -> int | None:
 
 
 def tag_name(node: Node) -> str:
-    return node.tagname  # type:ignore[attr-defined,no-any-return] # noqa: SC200
+    return node.tagname  # type:ignore[attr-defined,no-any-return]
 
 
 def get_insert_index(app: Sphinx, lines: list[str]) -> InsertIndexInfo | None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -999,6 +999,174 @@ def google_docstrings(arg1: CodeType, arg2: ModuleType) -> CodeType:  # noqa: U1
     """
 
 
+@expected(
+    """
+    mod.docstring_with_multiline_note_after_params(param)
+
+       Do something.
+
+       Parameters:
+          **param** ("int") -- A parameter.
+
+       Return type:
+          "None"
+
+       Note:
+
+         Some notes. More notes
+
+    """
+)
+def docstring_with_multiline_note_after_params(param: int) -> None:  # noqa: U100
+    """Do something.
+
+    Args:
+        param: A parameter.
+
+    Note:
+
+        Some notes.
+        More notes
+    """
+
+
+@expected(
+    """
+    mod.docstring_with_bullet_list_after_params(param)
+
+       Do something.
+
+       Parameters:
+          **param** ("int") -- A parameter.
+
+       Return type:
+          "None"
+
+       * A: B
+
+       * C: D
+
+    """
+)
+def docstring_with_bullet_list_after_params(param: int) -> None:  # noqa: U100
+    """Do something.
+
+    Args:
+        param: A parameter.
+
+    * A: B
+    * C: D
+    """
+
+
+@expected(
+    """
+    mod.docstring_with_definition_list_after_params(param)
+
+       Do something.
+
+       Parameters:
+          **param** ("int") -- A parameter.
+
+       Return type:
+          "None"
+
+       Term
+          A description
+
+          maybe multiple lines
+
+       Next Term
+          Somethign about it
+
+    """
+)
+def docstring_with_definition_list_after_params(param: int) -> None:  # noqa: U100
+    """Do something.
+
+    Args:
+        param: A parameter.
+
+    Term
+        A description
+
+        maybe multiple lines
+
+    Next Term
+        Somethign about it
+    """
+
+
+@expected(
+    """
+    mod.docstring_with_enum_list_after_params(param)
+
+       Do something.
+
+       Parameters:
+          **param** ("int") -- A parameter.
+
+       Return type:
+          "None"
+
+       1. A: B
+
+       2. C: D
+
+    """
+)
+def docstring_with_enum_list_after_params(param: int) -> None:  # noqa: U100
+    """Do something.
+
+    Args:
+        param: A parameter.
+
+    1. A: B
+    2. C: D
+    """
+
+
+@warns("Definition list ends without a blank line")
+@expected(
+    """
+    mod.docstring_with_definition_list_after_params_no_blank_line(param)
+
+       Do something.
+
+       Parameters:
+          **param** ("int") -- A parameter.
+
+       Return type:
+          "None"
+
+       Term
+          A description
+
+          maybe multiple lines
+
+       Next Term
+          Somethign about it
+
+       -[ Example ]-
+    """
+)
+def docstring_with_definition_list_after_params_no_blank_line(param: int) -> None:  # noqa: U100
+    """Do something.
+
+    Args:
+        param: A parameter.
+
+    Term
+        A description
+
+        maybe multiple lines
+
+    Next Term
+        Somethign about it
+    .. rubric:: Example
+    """
+
+
 AUTO_FUNCTION = ".. autofunction:: mod.{}"
 AUTO_CLASS = """\
 .. autoclass:: mod.{}

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -39,6 +39,7 @@ isfunction
 iterdir
 kwonlyargs
 libs
+lineno
 lru
 metaclass
 ModuleType
@@ -73,6 +74,7 @@ stmt
 stringify
 subclasses
 supertype
+tagname
 tempdir
 testroot
 textwrap


### PR DESCRIPTION
This resolves #312. 

The missing line numbers make it impossible for us to correctly calculate where to place the rtype.

See upstream issue:
https://sourceforge.net/p/docutils/bugs/465/

I submitted a patch to docutils to fix these things but it is currently waiting to get through a spam filter. The docutils test suite has no coverage checking whether this field is filled correctly.