### PR TITLE
Enable parallel write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.22 
+## 1.22
 
 - Allow Sphinx explicitly to write in parallel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## 1.22 
 
 - Allow Sphinx explicitly to write in parallel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Allow Sphinx explicitly to write in parallel.
+
 ## 1.21.7
 
 - Fixed a bug where if a class has an attribute and a constructor argument with the same name, the constructor argument

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -798,7 +798,7 @@ def setup(app: Sphinx) -> dict[str, bool]:
     app.connect("autodoc-process-signature", process_signature)
     app.connect("autodoc-process-docstring", process_docstring)
     install_patches(app)
-    return {"parallel_read_safe": True}
+    return {"parallel_read_safe": True, "parallel_write_safe": True}
 
 
 __all__ = [


### PR DESCRIPTION
in #9 parallel reading was enabled. Now lets do the same for writing. I've tested this with my (large) project locally. The output looks sane and the total build time was cut in half.