### PR TITLE
FIX TypeError: unhashable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Fixed napoleon handling of numpy docstrings with no specified return type.
 
+- Fixed crash when documenting ParamSpecArgs
+
 ## 1.21.6
 
 - Fix a `Field list ends without a blank line` warning (issue 305).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.22
 
 - Allow Sphinx explicitly to write in parallel.
+- Fixed crash when documenting ParamSpecArgs
 
 ## 1.21.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 - Fixed napoleon handling of numpy docstrings with no specified return type.
 
-- Fixed crash when documenting ParamSpecArgs
-
 ## 1.21.6
 
 - Fix a `Field list ends without a blank line` warning (issue 305).

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -7,7 +7,7 @@ import textwrap
 import types
 from ast import FunctionDef, Module, stmt
 from dataclasses import dataclass
-from typing import Any, AnyStr, Callable, ForwardRef, NewType, Optional, TypeVar, get_type_hints
+from typing import Any, AnyStr, Callable, ForwardRef, NewType, TypeVar, get_type_hints
 
 from docutils.frontend import OptionParser
 from docutils.nodes import Node

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -49,7 +49,11 @@ def get_annotation_module(annotation: Any) -> str:
     if annotation is None:
         return "builtins"
     is_new_type = sys.version_info >= (3, 10) and isinstance(annotation, NewType)
-    if is_new_type or isinstance(annotation, TypeVar) or type(annotation).__name__ in ("ParamSpec", 'ParamSpecArgs', 'ParamSpecKwargs'):
+    if (
+        is_new_type
+        or isinstance(annotation, TypeVar)
+        or type(annotation).__name__ in ("ParamSpec", "ParamSpecArgs", "ParamSpecKwargs")
+    ):
         return "typing"
     if hasattr(annotation, "__module__"):
         return annotation.__module__  # type: ignore # deduced Any

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -38,16 +38,16 @@ _TYPES_DICT[types.FunctionType] = "FunctionType"
 def _get_types_type(obj: Any) -> str | None:
     try:
         return _TYPES_DICT.get(obj)
-    except TypeError:
+    except:
         # e.g. exception: unhashable type
         return None
 
 
 def get_annotation_module(annotation: Any) -> str:
-    if _get_types_type(annotation) is not None:
-        return "types"
     if annotation is None:
         return "builtins"
+    if _get_types_type(annotation) is not None:
+        return "types"
     is_new_type = sys.version_info >= (3, 10) and isinstance(annotation, NewType)
     if (
         is_new_type

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -7,7 +7,7 @@ import textwrap
 import types
 from ast import FunctionDef, Module, stmt
 from dataclasses import dataclass
-from typing import Any, AnyStr, Callable, ForwardRef, NewType, TypeVar, get_type_hints, Optional
+from typing import Any, AnyStr, Callable, ForwardRef, NewType, Optional, TypeVar, get_type_hints
 
 from docutils.frontend import OptionParser
 from docutils.nodes import Node
@@ -35,7 +35,7 @@ _TYPES_DICT = {getattr(types, name): name for name in types.__all__}
 _TYPES_DICT[types.FunctionType] = "FunctionType"
 
 
-def _get_types_type(obj: Any) -> Optional[str]:
+def _get_types_type(obj: Any) -> str | None:
     try:
         return _TYPES_DICT.get(obj)
     except TypeError:

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -38,7 +38,7 @@ _TYPES_DICT[types.FunctionType] = "FunctionType"
 def _get_types_type(obj: Any) -> str | None:
     try:
         return _TYPES_DICT.get(obj)
-    except:
+    except Exception:
         # e.g. exception: unhashable type
         return None
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -7,7 +7,7 @@ import textwrap
 import types
 from ast import FunctionDef, Module, stmt
 from dataclasses import dataclass
-from typing import Any, AnyStr, Callable, ForwardRef, NewType, TypeVar, get_type_hints
+from typing import Any, AnyStr, Callable, ForwardRef, NewType, TypeVar, get_type_hints, Optional
 
 from docutils.frontend import OptionParser
 from docutils.nodes import Node
@@ -35,7 +35,7 @@ _TYPES_DICT = {getattr(types, name): name for name in types.__all__}
 _TYPES_DICT[types.FunctionType] = "FunctionType"
 
 
-def get_types_type(obj):
+def _get_types_type(obj: Any) -> Optional[str]:
     try:
         return _TYPES_DICT.get(obj)
     except TypeError:
@@ -44,7 +44,7 @@ def get_types_type(obj):
 
 
 def get_annotation_module(annotation: Any) -> str:
-    if get_types_type(annotation) is not None:
+    if _get_types_type(annotation) is not None:
         return "types"
     if annotation is None:
         return "builtins"
@@ -75,7 +75,7 @@ def get_annotation_class_name(annotation: Any, module: str) -> str:
         return "None"
     if annotation is AnyStr:
         return "AnyStr"
-    val = get_types_type(annotation)
+    val = _get_types_type(annotation)
     if val is not None:
         return val
     if _is_newtype(annotation):

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -58,6 +58,8 @@ Z = TypeVar("Z", bound="A")
 S = TypeVar("S", bound="miss")  # type: ignore # miss not defined on purpose # noqa: F821
 W = NewType("W", str)
 P = typing_extensions.ParamSpec("P")
+P_args = P.args
+P_kwargs = P.kwargs
 P_co = typing_extensions.ParamSpec("P_co", covariant=True)  # type: ignore
 P_contra = typing_extensions.ParamSpec("P_contra", contravariant=True)  # type: ignore
 P_bound = typing_extensions.ParamSpec("P_bound", bound=str)  # type: ignore
@@ -163,6 +165,9 @@ else:
         pytest.param(Match[str], "typing", "Match", (str,), id="Match_parametrized"),
         pytest.param(IO, "typing", "IO", (), id="IO"),
         pytest.param(W, "typing", "NewType", (str,), id="W"),
+        pytest.param(P, "typing", "ParamSpec", (), id="P"),
+        pytest.param(P_args, "typing", "ParamSpecArgs", (), id="P_args"),
+        pytest.param(P_kwargs, "typing", "ParamSpecKwargs", (), id="P_kwargs"),
         pytest.param(Metaclass, __name__, "Metaclass", (), id="Metaclass"),
         pytest.param(Slotted, __name__, "Slotted", (), id="Slotted"),
         pytest.param(A, __name__, "A", (), id="A"),

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -58,8 +58,8 @@ Z = TypeVar("Z", bound="A")
 S = TypeVar("S", bound="miss")  # type: ignore # miss not defined on purpose # noqa: F821
 W = NewType("W", str)
 P = typing_extensions.ParamSpec("P")
-P_args = P.args
-P_kwargs = P.kwargs
+P_args = P.args  # type:ignore[attr-defined]
+P_kwargs = P.kwargs  # type:ignore[attr-defined]
 P_co = typing_extensions.ParamSpec("P_co", covariant=True)  # type: ignore
 P_contra = typing_extensions.ParamSpec("P_contra", contravariant=True)  # type: ignore
 P_bound = typing_extensions.ParamSpec("P_bound", bound=str)  # type: ignore


### PR DESCRIPTION
Attempt to fix #318.
The access to `_TYPES_DICT` should be wrapped so the error for unhashable type is captured.
This is just a quick hack that fixes the issue for me and there sure is a more elegant way of doing it ...