### PR TITLE
Handle attrs forward refs

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -358,11 +358,22 @@ def get_all_type_hints(autodoc_mock_imports: list[str], obj: Any, name: str) -> 
 
 
 _TYPE_GUARD_IMPORT_RE = re.compile(r"\nif (typing.)?TYPE_CHECKING:[^\n]*([\s\S]*?)(?=\n\S)")
-
+_TYPE_GUARD_IMPORTS_RESOLVED = set()
+_TYPE_GUARD_IMPORTS_RESOLVED_GLOBALS_ID = set()
 
 def _resolve_type_guarded_imports(autodoc_mock_imports: list[str], obj: Any) -> None:
-    if hasattr(obj, "__module__"):
+    if (
+        hasattr(obj, "__module__")
+        and obj.__module__ not in _TYPE_GUARD_IMPORTS_RESOLVED
+    ) or (
+        hasattr(obj, "__globals__")
+        and id(obj.__globals__) not in _TYPE_GUARD_IMPORTS_RESOLVED_GLOBALS_ID
+    ):
+        _TYPE_GUARD_IMPORTS_RESOLVED.add(obj.__module__)
         if obj.__module__ not in sys.builtin_module_names:
+            if hasattr(obj, "__globals__"):
+                _TYPE_GUARD_IMPORTS_RESOLVED_GLOBALS_ID.add(id(obj.__globals__))
+
             module = inspect.getmodule(obj)
             if module:
                 try:

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -358,12 +358,10 @@ def get_all_type_hints(autodoc_mock_imports: list[str], obj: Any, name: str) -> 
 
 
 _TYPE_GUARD_IMPORT_RE = re.compile(r"\nif (typing.)?TYPE_CHECKING:[^\n]*([\s\S]*?)(?=\n\S)")
-_TYPE_GUARD_IMPORTS_RESOLVED = set()
 
 
 def _resolve_type_guarded_imports(autodoc_mock_imports: list[str], obj: Any) -> None:
-    if hasattr(obj, "__module__") and obj.__module__ not in _TYPE_GUARD_IMPORTS_RESOLVED:
-        _TYPE_GUARD_IMPORTS_RESOLVED.add(obj.__module__)
+    if hasattr(obj, "__module__"):
         if obj.__module__ not in sys.builtin_module_names:
             module = inspect.getmodule(obj)
             if module:

--- a/tests/roots/test-resolve-typing-guard-tmp/conf.py
+++ b/tests/roots/test-resolve-typing-guard-tmp/conf.py
@@ -1,0 +1,9 @@
+import pathlib
+import sys
+
+master_doc = "index"
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
+]

--- a/tests/roots/test-resolve-typing-guard-tmp/demo_typing_guard.py
+++ b/tests/roots/test-resolve-typing-guard-tmp/demo_typing_guard.py
@@ -1,0 +1,59 @@
+"""Module demonstrating imports that are type guarded"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from attrs import define
+
+if TYPE_CHECKING:
+    import datetime
+
+
+@define()
+class SomeClass:
+    """This class does something."""
+
+    dt: datetime.date
+    """Date to handle"""
+
+    @classmethod
+    def from_str(cls, inp_v: str) -> SomeClass:
+        """
+        Initialise from string
+
+        :param inp_v: Input
+        :return: result
+        """
+        return cls()
+
+    @classmethod
+    def from_date(cls, inp_v: datetime.date) -> SomeClass:
+        """
+        Initialise from date
+
+        :param inp_v: Input
+        :return: result
+        """
+        return cls()
+
+    @classmethod
+    def from_time(cls, inp_v: datetime.time) -> SomeClass:
+        """
+        Initialise from time
+
+        :param inp_v: Input
+        :return: result
+        """
+        return cls()
+
+    def calc_thing(self, num: float) -> datetime.timedelta:
+        """
+        Calculate a thing
+
+        :param num: Input
+        :return: result
+        """
+        return datetime.timedelta(num)
+
+
+__all__ = ["SomeClass"]

--- a/tests/roots/test-resolve-typing-guard-tmp/index.rst
+++ b/tests/roots/test-resolve-typing-guard-tmp/index.rst
@@ -1,0 +1,2 @@
+.. automodule:: demo_typing_guard
+   :members:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -754,6 +754,14 @@ def test_resolve_typing_guard_imports(app: SphinxTestApp, status: StringIO, warn
     assert re.search(pat, err)
 
 
+@pytest.mark.sphinx("text", testroot="resolve-typing-guard-tmp")
+def test_resolve_typing_guard_tmp_imports(app: SphinxTestApp, status: StringIO, warning: StringIO) -> None:
+    set_python_path()
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert not warning.getvalue()
+
+
 def test_no_source_code_type_guard() -> None:
     from csv import Error
 


### PR DESCRIPTION
These seems to be an issue in the interaction between sphinx-autodoc-typehints and attrs. The current implementation evaluates guarded imports into `obj.__globals__`. However, something happens with attrs where `obj.__globals__` is not the same for all objects within the same module, so the current implementation doesn't work. 

As far as I can tell, the current implementation uses `_TYPE_GUARD_IMPORTS_RESOLVED` to avoid doing the imports more than is necessary. Simply removing this fixes the issue (see commit d611358a1ef446cca2bda975e0c59913c2b3e65b). Alternately, an extra guard can be added to handle this attrs problem (see commit b68ea0377496c26a240dc4e31af055b3097c53fd).

As a final note, I don't know whether there is a problem with attrs which should be fixed (e.g. this issue seems related https://github.com/python-attrs/attrs/issues/1021) or whether sphinx-autodoc-typehints needs to change to support attrs way of doing things.