### PR TITLE
Stop parsing from overwriting Sphinx configuration

### DIFF
--- a/src/sphinx_autodoc_typehints/attributes_patch.py
+++ b/src/sphinx_autodoc_typehints/attributes_patch.py
@@ -13,8 +13,7 @@ from sphinx.ext.autodoc import AttributeDocumenter
 from .parser import parse
 
 if TYPE_CHECKING:
-    from optparse import Values
-
+    from docutils.frontend import Values
     from sphinx.addnodes import desc_signature
     from sphinx.application import Sphinx
 
@@ -64,7 +63,7 @@ def rst_to_docutils(settings: Values, rst: str) -> Any:
     """Convert rst to a sequence of docutils nodes."""
     doc = parse(rst, settings)
     # Remove top level paragraph node so that there is no line break.
-    return doc.children[0].children
+    return doc.children[0].children  # type:ignore[attr-defined]
 
 
 def patched_parse_annotation(settings: Values, typ: str, env: Any) -> Any:

--- a/src/sphinx_autodoc_typehints/attributes_patch.py
+++ b/src/sphinx_autodoc_typehints/attributes_patch.py
@@ -63,7 +63,7 @@ def rst_to_docutils(settings: Values, rst: str) -> Any:
     """Convert rst to a sequence of docutils nodes."""
     doc = parse(rst, settings)
     # Remove top level paragraph node so that there is no line break.
-    return doc.children[0].children  # type:ignore[attr-defined]
+    return doc.children[0].children
 
 
 def patched_parse_annotation(settings: Values, typ: str, env: Any) -> Any:

--- a/src/sphinx_autodoc_typehints/attributes_patch.py
+++ b/src/sphinx_autodoc_typehints/attributes_patch.py
@@ -7,10 +7,10 @@ from unittest.mock import patch
 
 import sphinx.domains.python
 import sphinx.ext.autodoc
-from docutils.parsers.rst import Parser as RstParser
-from docutils.utils import new_document
 from sphinx.domains.python import PyAttribute
 from sphinx.ext.autodoc import AttributeDocumenter
+
+from .parser import parse
 
 if TYPE_CHECKING:
     from optparse import Values
@@ -62,8 +62,7 @@ def patch_attribute_documenter(app: Sphinx) -> None:
 
 def rst_to_docutils(settings: Values, rst: str) -> Any:
     """Convert rst to a sequence of docutils nodes."""
-    doc = new_document("", settings)
-    RstParser().parse(rst, doc)
+    doc = parse(rst, settings)
     # Remove top level paragraph node so that there is no line break.
     return doc.children[0].children
 

--- a/src/sphinx_autodoc_typehints/parser.py
+++ b/src/sphinx_autodoc_typehints/parser.py
@@ -1,0 +1,24 @@
+"""Utilities for side-effect-free rST parsing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docutils.utils import new_document
+from sphinx.parsers import RSTParser
+from sphinx.util.docutils import sphinx_domains
+
+if TYPE_CHECKING:
+    from optparse import Values
+
+    from docutils import nodes
+
+
+def parse(inputstr: str, settings: Values) -> nodes.document:
+    """Parse inputstr and return a docutils document."""
+    doc = new_document("", settings=settings)
+    with sphinx_domains(settings.env):
+        parser = RSTParser()
+        parser.set_application(settings.env.app)
+        parser.parse(inputstr, doc)
+    return doc

--- a/src/sphinx_autodoc_typehints/parser.py
+++ b/src/sphinx_autodoc_typehints/parser.py
@@ -9,11 +9,13 @@ from sphinx.parsers import RSTParser
 from sphinx.util.docutils import sphinx_domains
 
 if TYPE_CHECKING:
+    import optparse
+
     from docutils import nodes
     from docutils.frontend import Values
 
 
-def parse(inputstr: str, settings: Values) -> nodes.document:
+def parse(inputstr: str, settings: Values | optparse.Values) -> nodes.document:
     """Parse inputstr and return a docutils document."""
     doc = new_document("", settings=settings)
     with sphinx_domains(settings.env):

--- a/src/sphinx_autodoc_typehints/parser.py
+++ b/src/sphinx_autodoc_typehints/parser.py
@@ -9,9 +9,8 @@ from sphinx.parsers import RSTParser
 from sphinx.util.docutils import sphinx_domains
 
 if TYPE_CHECKING:
-    from optparse import Values
-
     from docutils import nodes
+    from docutils.frontend import Values
 
 
 def parse(inputstr: str, settings: Values) -> nodes.document:

--- a/tests/roots/test-dummy/dummy_module_future_annotations.py
+++ b/tests/roots/test-dummy/dummy_module_future_annotations.py
@@ -10,7 +10,7 @@ def function_with_py310_annotations(
     """
     Method docstring.
 
-    :param x: foo
+    :param x: `foo`
     :param y: bar
     :param z: baz
     """

--- a/tests/roots/test-dummy/dummy_module_future_annotations.py
+++ b/tests/roots/test-dummy/dummy_module_future_annotations.py
@@ -10,7 +10,7 @@ def function_with_py310_annotations(
     """
     Method docstring.
 
-    :param x: `foo`
+    :param x: foo
     :param y: bar
     :param z: baz
     """

--- a/tests/roots/test-dummy/dummy_module_simple_default_role.py
+++ b/tests/roots/test-dummy/dummy_module_simple_default_role.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+def function(x: bool, y: int) -> str:  # noqa: ARG001
+    """
+    Function docstring.
+
+    :param x: `foo`
+    :param y: ``bar``
+    """

--- a/tests/roots/test-dummy/simple_default_role.rst
+++ b/tests/roots/test-dummy/simple_default_role.rst
@@ -1,0 +1,4 @@
+Simple Module
+=============
+
+.. autofunction:: dummy_module_simple_default_role.function

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -573,7 +573,7 @@ def test_sphinx_output_default_role(app: SphinxTestApp, status: StringIO) -> Non
     set_python_path()
 
     app.config.master_doc = "simple_default_role"  # type: ignore[attr-defined] # create flag
-    app.config.default_role = "literal"
+    app.config.default_role = "literal"  # type: ignore[attr-defined]
     app.build()
 
     assert "build succeeded" in status.getvalue()  # Build succeeded

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -554,7 +554,7 @@ def test_sphinx_output_future_annotations(app: SphinxTestApp, status: StringIO) 
        Method docstring.
 
        Parameters:
-          * **x** (bool | None) -- foo
+          * **x** (bool | None) -- *foo*
 
           * **y** ("int" | "str" | "float") -- bar
 
@@ -565,6 +565,42 @@ def test_sphinx_output_future_annotations(app: SphinxTestApp, status: StringIO) 
     """
     expected_contents = maybe_fix_py310(dedent(expected_contents))
     assert contents == expected_contents
+
+
+@pytest.mark.sphinx("pseudoxml", testroot="dummy")
+@patch("sphinx.writers.text.MAXWIDTH", 2000)
+def test_sphinx_output_default_role(app: SphinxTestApp, status: StringIO) -> None:
+    set_python_path()
+
+    app.config.master_doc = "future_annotations"  # type: ignore[attr-defined] # create flag
+    app.config.default_role = "literal"
+    app.build()
+
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+
+    contents_lines = (Path(app.srcdir) / "_build/pseudoxml/future_annotations.pseudoxml").read_text().splitlines()
+    list_item_idxs = [i for i, line in enumerate(contents_lines) if line.strip() == "<list_item>"]
+    foo_param = dedent("\n".join(contents_lines[list_item_idxs[0] : list_item_idxs[1]]))
+    expected_foo_param = """\
+    <list_item>
+        <paragraph>
+            <literal_strong>
+                x
+             (
+            <inline classes="sphinx_autodoc_typehints-type">
+                <literal classes="xref py py-data">
+                    Optional
+                [
+                <literal classes="xref py py-class">
+                    bool
+                ]
+            )
+             \N{EN DASH}\N{SPACE}
+            <literal>
+                foo
+    """.rstrip()
+    expected_foo_param = maybe_fix_py310(dedent(expected_foo_param))
+    assert foo_param == expected_foo_param
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -554,7 +554,7 @@ def test_sphinx_output_future_annotations(app: SphinxTestApp, status: StringIO) 
        Method docstring.
 
        Parameters:
-          * **x** (bool | None) -- *foo*
+          * **x** (bool | None) -- foo
 
           * **y** ("int" | "str" | "float") -- bar
 
@@ -572,13 +572,13 @@ def test_sphinx_output_future_annotations(app: SphinxTestApp, status: StringIO) 
 def test_sphinx_output_default_role(app: SphinxTestApp, status: StringIO) -> None:
     set_python_path()
 
-    app.config.master_doc = "future_annotations"  # type: ignore[attr-defined] # create flag
+    app.config.master_doc = "simple_default_role"  # type: ignore[attr-defined] # create flag
     app.config.default_role = "literal"
     app.build()
 
     assert "build succeeded" in status.getvalue()  # Build succeeded
 
-    contents_lines = (Path(app.srcdir) / "_build/pseudoxml/future_annotations.pseudoxml").read_text().splitlines()
+    contents_lines = (Path(app.srcdir) / "_build/pseudoxml/simple_default_role.pseudoxml").read_text().splitlines()
     list_item_idxs = [i for i, line in enumerate(contents_lines) if line.strip() == "<list_item>"]
     foo_param = dedent("\n".join(contents_lines[list_item_idxs[0] : list_item_idxs[1]]))
     expected_foo_param = """\
@@ -588,18 +588,14 @@ def test_sphinx_output_default_role(app: SphinxTestApp, status: StringIO) -> Non
                 x
              (
             <inline classes="sphinx_autodoc_typehints-type">
-                <literal classes="xref py py-data">
-                    Optional
-                [
                 <literal classes="xref py py-class">
                     bool
-                ]
             )
              \N{EN DASH}\N{SPACE}
             <literal>
                 foo
     """.rstrip()
-    expected_foo_param = maybe_fix_py310(dedent(expected_foo_param))
+    expected_foo_param = dedent(expected_foo_param)
     assert foo_param == expected_foo_param
 
 


### PR DESCRIPTION
Fixes #421, fixes https://github.com/scverse/scanpy/issues/2829

This PR introduces a `parse` function that abstracts away the instantiation and use of a `RSTParser` instance.

It uses the `sphinx.util.docutils:sphinx_domains` context manager to make sure that the `docutils` directive and role registries are managed properly.