### PR TITLE
Add warning type and subtype

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -361,7 +361,7 @@ def process_signature(  # noqa: C901, PLR0913, PLR0917
         elif what == "method":
             # bail if it is a local method as we cannot determine if first argument needs to be deleted or not
             if "<locals>" in obj.__qualname__ and not _is_dataclass(name, what, obj.__qualname__):
-                _LOGGER.warning('Cannot handle as a local function: "%s" (use @functools.wraps)', name)
+                _LOGGER.warning('Cannot handle as a local function: "%s" (use @functools.wraps)', name, type='sphinx_autodoc_typehints', subtype='local_function')
                 return None
             outer = inspect.getmodule(obj)
             for class_name in obj.__qualname__.split(".")[:-1]:
@@ -453,7 +453,7 @@ def _execute_guarded_code(autodoc_mock_imports: list[str], obj: Any, module_code
                     with mock(autodoc_mock_imports):
                         exec(guarded_code, getattr(obj, "__globals__", obj.__dict__))  # noqa: S102
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.warning("Failed guarded type import with %r", exc)
+            _LOGGER.warning("Failed guarded type import with %r", exc, type='sphinx_autodoc_typehints', subtype='guarded_import')
 
 
 def _resolve_type_guarded_imports(autodoc_mock_imports: list[str], obj: Any) -> None:
@@ -487,7 +487,7 @@ def _get_type_hint(autodoc_mock_imports: list[str], name: str, obj: Any) -> dict
         else:
             result = {}
     except NameError as exc:
-        _LOGGER.warning('Cannot resolve forward reference in type annotations of "%s": %s', name, exc)
+        _LOGGER.warning('Cannot resolve forward reference in type annotations of "%s": %s', name, exc, type='sphinx_autodoc_typehints', subtype='forward_reference')
         result = obj.__annotations__
     return result
 
@@ -505,7 +505,7 @@ def backfill_type_hints(obj: Any, name: str) -> dict[str, Any]:  # noqa: C901, P
     def _one_child(module: Module) -> stmt | None:
         children = module.body  # use the body to ignore type comments
         if len(children) != 1:
-            _LOGGER.warning('Did not get exactly one node from AST for "%s", got %s', name, len(children))
+            _LOGGER.warning('Did not get exactly one node from AST for "%s", got %s', name, len(children), type='sphinx_autodoc_typehints')
             return None
         return children[0]
 
@@ -530,7 +530,7 @@ def backfill_type_hints(obj: Any, name: str) -> dict[str, Any]:  # noqa: C901, P
     try:
         comment_args_str, comment_returns = type_comment.split(" -> ")
     except ValueError:
-        _LOGGER.warning('Unparseable type hint comment for "%s": Expected to contain ` -> `', name)
+        _LOGGER.warning('Unparseable type hint comment for "%s": Expected to contain ` -> `', name, type='sphinx_autodoc_typehints', subtype='comment')
         return {}
 
     rv = {}
@@ -545,7 +545,7 @@ def backfill_type_hints(obj: Any, name: str) -> dict[str, Any]:  # noqa: C901, P
             comment_args.insert(0, None)  # self/cls may be omitted in type comments, insert blank
 
         if len(args) != len(comment_args):
-            _LOGGER.warning('Not enough type comments found on "%s"', name)
+            _LOGGER.warning('Not enough type comments found on "%s"', name, type='sphinx_autodoc_typehints', subtype='comment')
             return rv
 
     for at, arg in enumerate(args):


### PR DESCRIPTION
This adds warning types so that warnings can be filtered by [`suppress_warnings`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-suppress_warnings). The implementation is analog to autodoc.

Since sphinx-autodoc-typehints imports Sphinx's logger which supports the type/subtype arguments, it was a simple change.

Closes #432