### PR TITLE
Return injection fix

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -779,6 +779,9 @@ def node_line_no(node: Node) -> int | None:
     docutils rst parser source code. An example where the node doesn't have a line number but the first child does is
     all `definition_list` nodes. It seems like bullet_list and option_list get line numbers, but enum_list also doesn't.
     """
+    if node is None:
+        return None
+
     while node.line is None and node.children:
         node = node.children[0]
     return node.line

--- a/src/sphinx_autodoc_typehints/parser.py
+++ b/src/sphinx_autodoc_typehints/parser.py
@@ -13,13 +13,20 @@ if TYPE_CHECKING:
 
     from docutils import nodes
     from docutils.frontend import Values
+    from docutils.statemachine import StringList
+
+
+class _RstSnippetParser(RSTParser):
+    @staticmethod
+    def decorate(_content: StringList) -> None:
+        """Override to skip processing rst_epilog/rst_prolog for typing."""
 
 
 def parse(inputstr: str, settings: Values | optparse.Values) -> nodes.document:
     """Parse inputstr and return a docutils document."""
     doc = new_document("", settings=settings)
     with sphinx_domains(settings.env):
-        parser = RSTParser()
+        parser = _RstSnippetParser()
         parser.set_application(settings.env.app)
         parser.parse(inputstr, doc)
     return doc

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1267,11 +1267,11 @@ def typehints_use_signature(a: AsyncGenerator) -> AsyncGenerator:
     """
     return a
 
+
 prolog = """
 .. |test_node_start| replace:: {test_node_start}
-""".format(
-    test_node_start="test_start"
-)
+""".format(test_node_start="test_start")
+
 
 @expected(
     """
@@ -1290,9 +1290,8 @@ prolog = """
          Some notes. test_start More notes
 
     """,
-    rst_prolog=prolog
+    rst_prolog=prolog,
 )
-
 def docstring_with_multiline_note_after_params_prolog_replace(param: int) -> None:  # noqa: ARG001
     """Do something.
 
@@ -1305,11 +1304,12 @@ def docstring_with_multiline_note_after_params_prolog_replace(param: int) -> Non
         More notes
     """
 
+
 epilog = """
 .. |test_node_end| replace:: {test_node_end}
-""".format(
-    test_node_end="test_end"
-)
+""".format(test_node_end="test_end")
+
+
 @expected(
     """
     mod.docstring_with_multiline_note_after_params_epilog_replace(param)
@@ -1327,9 +1327,8 @@ epilog = """
          Some notes. test_end More notes
 
     """,
-    rst_epilog=epilog
+    rst_epilog=epilog,
 )
-
 def docstring_with_multiline_note_after_params_epilog_replace(param: int) -> None:  # noqa: ARG001
     """Do something.
 
@@ -1342,20 +1341,19 @@ def docstring_with_multiline_note_after_params_epilog_replace(param: int) -> Non
         More notes
     """
 
+
 # Config settings for each test run.
 # Config Name: Sphinx Options as Dict.
 configs = {
     "default_conf": {},
-    "prolog_conf": {
-        "rst_prolog": prolog
-    },
+    "prolog_conf": {"rst_prolog": prolog},
     "epilog_conf": {
         "rst_epilog": epilog,
     },
     "bothlog_conf": {
         "rst_prolog": prolog,
         "rst_epilog": epilog,
-    }
+    },
 }
 
 
@@ -1363,12 +1361,7 @@ configs = {
 @pytest.mark.parametrize("conf_run", ["default_conf", "prolog_conf", "epilog_conf", "bothlog_conf"])
 @pytest.mark.sphinx("text", testroot="integration")
 def test_integration(
-    app: SphinxTestApp,
-    status: StringIO,
-    warning: StringIO,
-    monkeypatch: pytest.MonkeyPatch,
-    val: Any,
-    conf_run: str
+    app: SphinxTestApp, status: StringIO, warning: StringIO, monkeypatch: pytest.MonkeyPatch, val: Any, conf_run: str
 ) -> None:
     if isclass(val) and issubclass(val, BaseException):
         template = AUTO_EXCEPTION

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1267,8 +1267,100 @@ def typehints_use_signature(a: AsyncGenerator) -> AsyncGenerator:
     """
     return a
 
+prolog = """
+.. |test_node_start| replace:: {test_node_start}
+""".format(
+    test_node_start="test_start"
+)
+
+@expected(
+    """
+    mod.docstring_with_multiline_note_after_params_prolog_replace(param)
+
+       Do something.
+
+       Parameters:
+          **param** ("int") -- A parameter.
+
+       Return type:
+          "None"
+
+       Note:
+
+         Some notes. test_start More notes
+
+    """,
+    rst_prolog=prolog
+)
+
+def docstring_with_multiline_note_after_params_prolog_replace(param: int) -> None:  # noqa: ARG001
+    """Do something.
+
+    Args:
+        param: A parameter.
+
+    Note:
+
+        Some notes. |test_node_start|
+        More notes
+    """
+
+epilog = """
+.. |test_node_end| replace:: {test_node_end}
+""".format(
+    test_node_end="test_end"
+)
+@expected(
+    """
+    mod.docstring_with_multiline_note_after_params_epilog_replace(param)
+
+       Do something.
+
+       Parameters:
+          **param** ("int") -- A parameter.
+
+       Return type:
+          "None"
+
+       Note:
+
+         Some notes. test_end More notes
+
+    """,
+    rst_epilog=epilog
+)
+
+def docstring_with_multiline_note_after_params_epilog_replace(param: int) -> None:  # noqa: ARG001
+    """Do something.
+
+    Args:
+        param: A parameter.
+
+    Note:
+
+        Some notes. |test_node_end|
+        More notes
+    """
+
+# Config settings for each test run.
+# Config Name: Sphinx Options as Dict.
+configs = {
+    "default_conf": {},
+    "prolog_conf": {
+        "rst_prolog": prolog
+    },
+    "epilog_conf": {
+        "rst_epilog": epilog,
+    },
+    "bothlog_conf": {
+        "rst_prolog": prolog,
+        "rst_epilog": epilog,
+    }
+}
+
 
 @pytest.mark.parametrize("val", [x for x in globals().values() if hasattr(x, "EXPECTED")])
+@pytest.mark.parametrize("conf_run", ["default_conf", "prolog_conf", "epilog_conf", "bothlog_conf"])
 @pytest.mark.sphinx("text", testroot="integration")
 def test_integration(
     app: SphinxTestApp,
@@ -1276,6 +1368,7 @@ def test_integration(
     warning: StringIO,
     monkeypatch: pytest.MonkeyPatch,
     val: Any,
+    conf_run: str
 ) -> None:
     if isclass(val) and issubclass(val, BaseException):
         template = AUTO_EXCEPTION
@@ -1285,6 +1378,7 @@ def test_integration(
         template = AUTO_FUNCTION
 
     (Path(app.srcdir) / "index.rst").write_text(template.format(val.__name__))
+    app.config.__dict__.update(configs[conf_run])
     app.config.__dict__.update(val.OPTIONS)
     monkeypatch.setitem(sys.modules, "mod", sys.modules[__name__])
     app.build()

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -607,7 +607,9 @@ def test_sphinx_output_default_role(app: SphinxTestApp, status: StringIO) -> Non
 
     assert "build succeeded" in status.getvalue()  # Build succeeded
 
-    contents_lines = (Path(app.srcdir) / "_build/pseudoxml/simple_default_role.pseudoxml").read_text().splitlines()
+    contents_lines = (
+        (Path(app.srcdir) / "_build/pseudoxml/simple_default_role.pseudoxml").read_text(encoding="utf-8").splitlines()
+    )
     list_item_idxs = [i for i, line in enumerate(contents_lines) if line.strip() == "<list_item>"]
     foo_param = dedent("\n".join(contents_lines[list_item_idxs[0] : list_item_idxs[1]]))
     expected_foo_param = """\


### PR DESCRIPTION
Resolves #444 and #425

Ignore the rst_epilog/rst_prolog during parsing type hints like #436 did. This still keeps the replacement behavior.

I tried adjusting the parsing, but the XML node line counting, and the list of lines given are too intertwined without rewriting it completely.

`test_sphinx_autodoc_typehints` was broken for me in Windows, so I have added an encoding kwarg for it to work.

EDIT: Working on making tests pass... and adding them.