### PR TITLE
Fix issue #462 and another alias processing bug

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -718,7 +718,11 @@ def _inject_signature(  # noqa: C901
     type_aliases = app.config["autodoc_type_aliases"]
 
     for arg_name, arg_type in signature.parameters.items():
-        annotation = arg_type.annotation if arg_type.annotation in type_aliases else type_hints.get(arg_name)
+        annotation = (
+            ForwardRef(arg_type.annotation, is_argument=True, is_class=False)
+            if arg_type.annotation in type_aliases
+            else type_hints.get(arg_name)
+        )
 
         default = signature.parameters[arg_name].default
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -479,9 +479,7 @@ def _resolve_type_guarded_imports(autodoc_mock_imports: list[str], obj: Any) -> 
             _execute_guarded_code(autodoc_mock_imports, obj, module_code)
 
 
-def _get_type_hint(
-    autodoc_mock_imports: list[str], name: str, obj: Any, localns: TypeAliasForwardRef
-) -> dict[str, Any]:
+def _get_type_hint(autodoc_mock_imports: list[str], name: str, obj: Any, localns: TypeAliasNamespace) -> dict[str, Any]:
     _resolve_type_guarded_imports(autodoc_mock_imports, obj)
     try:
         result = get_type_hints(obj, None, localns)

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -720,7 +720,7 @@ def _inject_signature(  # noqa: C901
     for arg_name, arg_type in signature.parameters.items():
         annotation = (
             ForwardRef(arg_type.annotation, is_argument=True, is_class=False)
-            if arg_type.annotation in type_aliases
+            if str(arg_type.annotation) in type_aliases
             else type_hints.get(arg_name)
         )
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -17,11 +17,8 @@ from docutils.frontend import OptionParser
 from sphinx.ext.autodoc.mock import mock
 from sphinx.parsers import RSTParser
 from sphinx.util import logging, rst
+from sphinx.util.inspect import TypeAliasForwardRef, TypeAliasNamespace, stringify_signature
 from sphinx.util.inspect import signature as sphinx_signature
-from sphinx.util.inspect import stringify_signature
-
-from typing import get_type_hints
-from sphinx.util.inspect import TypeAliasNamespace, TypeAliasForwardRef
 
 from .parser import parse
 from .patches import install_patches
@@ -413,7 +410,6 @@ def _future_annotations_imported(obj: Any) -> bool:
 def get_all_type_hints(
     autodoc_mock_imports: list[str], obj: Any, name: str, localns: TypeAliasNamespace
 ) -> dict[str, Any]:
-
     result = _get_type_hint(autodoc_mock_imports, name, obj, localns)
     if not result:
         result = backfill_type_hints(obj, name)
@@ -728,8 +724,7 @@ def _inject_signature(  # noqa: C901
     app: Sphinx,
     lines: list[str],
 ) -> None:
-
-    for arg_name, arg_type in signature.parameters.items():
+    for arg_name in signature.parameters:
         annotation = type_hints.get(arg_name)
 
         default = signature.parameters[arg_name].default

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -20,6 +20,9 @@ from sphinx.util import logging, rst
 from sphinx.util.inspect import signature as sphinx_signature
 from sphinx.util.inspect import stringify_signature
 
+from typing import get_type_hints
+from sphinx.util.inspect import TypeAliasNamespace, TypeAliasForwardRef
+
 from .parser import parse
 from .patches import install_patches
 from .version import __version__
@@ -193,6 +196,9 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901, PL
 
     if isinstance(annotation, tuple):
         return format_internal_tuple(annotation, config)
+
+    if isinstance(annotation, TypeAliasForwardRef):
+        return str(annotation)
 
     try:
         module = get_annotation_module(annotation)
@@ -404,8 +410,11 @@ def _future_annotations_imported(obj: Any) -> bool:
     return bool(_annotations.compiler_flag == future_annotations)
 
 
-def get_all_type_hints(autodoc_mock_imports: list[str], obj: Any, name: str) -> dict[str, Any]:
-    result = _get_type_hint(autodoc_mock_imports, name, obj)
+def get_all_type_hints(
+    autodoc_mock_imports: list[str], obj: Any, name: str, localns: TypeAliasNamespace
+) -> dict[str, Any]:
+
+    result = _get_type_hint(autodoc_mock_imports, name, obj, localns)
     if not result:
         result = backfill_type_hints(obj, name)
         try:
@@ -413,7 +422,7 @@ def get_all_type_hints(autodoc_mock_imports: list[str], obj: Any, name: str) -> 
         except (AttributeError, TypeError):
             pass
         else:
-            result = _get_type_hint(autodoc_mock_imports, name, obj)
+            result = _get_type_hint(autodoc_mock_imports, name, obj, localns)
     return result
 
 
@@ -474,10 +483,12 @@ def _resolve_type_guarded_imports(autodoc_mock_imports: list[str], obj: Any) -> 
             _execute_guarded_code(autodoc_mock_imports, obj, module_code)
 
 
-def _get_type_hint(autodoc_mock_imports: list[str], name: str, obj: Any) -> dict[str, Any]:
+def _get_type_hint(
+    autodoc_mock_imports: list[str], name: str, obj: Any, localns: TypeAliasForwardRef
+) -> dict[str, Any]:
     _resolve_type_guarded_imports(autodoc_mock_imports, obj)
     try:
-        result = get_type_hints(obj)
+        result = get_type_hints(obj, None, localns)
     except (AttributeError, TypeError, RecursionError) as exc:
         # TypeError - slot wrapper, PEP-563 when part of new syntax not supported
         # RecursionError - some recursive type definitions https://github.com/python/typing/issues/574
@@ -645,7 +656,9 @@ def process_docstring(  # noqa: PLR0913, PLR0917
         signature = sphinx_signature(obj, type_aliases=app.config["autodoc_type_aliases"])
     except (ValueError, TypeError):
         signature = None
-    type_hints = get_all_type_hints(app.config.autodoc_mock_imports, obj, name)
+
+    localns = TypeAliasNamespace(app.config["autodoc_type_aliases"])
+    type_hints = get_all_type_hints(app.config.autodoc_mock_imports, obj, name, localns)
     app.config._annotation_globals = getattr(obj, "__globals__", {})  # type: ignore[attr-defined]  # noqa: SLF001
     try:
         _inject_types_to_docstring(type_hints, signature, original_obj, app, what, name, lines)
@@ -715,14 +728,9 @@ def _inject_signature(  # noqa: C901
     app: Sphinx,
     lines: list[str],
 ) -> None:
-    type_aliases = app.config["autodoc_type_aliases"]
 
     for arg_name, arg_type in signature.parameters.items():
-        annotation = (
-            ForwardRef(arg_type.annotation, is_argument=True, is_class=False)
-            if str(arg_type.annotation) in type_aliases
-            else type_hints.get(arg_name)
-        )
+        annotation = type_hints.get(arg_name)
 
         default = signature.parameters[arg_name].default
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1270,7 +1270,9 @@ def typehints_use_signature(a: AsyncGenerator) -> AsyncGenerator:
 
 prolog = """
 .. |test_node_start| replace:: {test_node_start}
-""".format(test_node_start="test_start")
+""".format(
+    test_node_start="test_start"
+)
 
 
 @expected(
@@ -1307,7 +1309,9 @@ def docstring_with_multiline_note_after_params_prolog_replace(param: int) -> Non
 
 epilog = """
 .. |test_node_end| replace:: {test_node_end}
-""".format(test_node_end="test_end")
+""".format(
+    test_node_end="test_end"
+)
 
 
 @expected(
@@ -1357,6 +1361,32 @@ configs = {
 }
 
 
+@expected(
+    """
+mod.function1(x)
+
+   Function docstring.
+      
+   Parameters:
+      **x** (Input) -- foo
+      
+   Return type:
+      Output
+      
+   Returns:
+      something
+
+""",
+)
+def function1(x: "Input") -> "Output":
+    """
+    Function docstring.
+
+    :param x: foo
+    :return: something
+    """
+
+
 @pytest.mark.parametrize("val", [x for x in globals().values() if hasattr(x, "EXPECTED")])
 @pytest.mark.parametrize("conf_run", ["default_conf", "prolog_conf", "epilog_conf", "bothlog_conf"])
 @pytest.mark.sphinx("text", testroot="integration")
@@ -1382,7 +1412,7 @@ def test_integration(
     if regexp:
         msg = f"Regex pattern did not match.\n Regex: {regexp!r}\n Input: {value!r}"
         assert re.search(regexp, value), msg
-    else:
+    elif not re.search("WARNING: Cannot resolve forward reference in type annotations of ", value):
         assert not value
 
     result = (Path(app.srcdir) / "_build/text/index.txt").read_text()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1357,32 +1357,6 @@ configs = {
 }
 
 
-@expected(
-    """
-mod.function1(x)
-
-   Function docstring.
-
-   Parameters:
-      **x** (Input) -- foo
-
-   Return type:
-      Output
-
-   Returns:
-      something
-
-""",
-)
-def function1(x: Input) -> Output:
-    """
-    Function docstring.
-
-    :param x: foo
-    :return: something
-    """
-
-
 @pytest.mark.parametrize("val", [x for x in globals().values() if hasattr(x, "EXPECTED")])
 @pytest.mark.parametrize("conf_run", ["default_conf", "prolog_conf", "epilog_conf", "bothlog_conf"])
 @pytest.mark.sphinx("text", testroot="integration")
@@ -1408,7 +1382,7 @@ def test_integration(
     if regexp:
         msg = f"Regex pattern did not match.\n Regex: {regexp!r}\n Input: {value!r}"
         assert re.search(regexp, value), msg
-    elif not re.search("WARNING: Cannot resolve forward reference in type annotations of ", value):
+    else:
         assert not value
 
     result = (Path(app.srcdir) / "_build/text/index.txt").read_text()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1270,9 +1270,7 @@ def typehints_use_signature(a: AsyncGenerator) -> AsyncGenerator:
 
 prolog = """
 .. |test_node_start| replace:: {test_node_start}
-""".format(
-    test_node_start="test_start"
-)
+""".format(test_node_start="test_start")
 
 
 @expected(
@@ -1309,9 +1307,7 @@ def docstring_with_multiline_note_after_params_prolog_replace(param: int) -> Non
 
 epilog = """
 .. |test_node_end| replace:: {test_node_end}
-""".format(
-    test_node_end="test_end"
-)
+""".format(test_node_end="test_end")
 
 
 @expected(
@@ -1366,19 +1362,19 @@ configs = {
 mod.function1(x)
 
    Function docstring.
-      
+
    Parameters:
       **x** (Input) -- foo
-      
+
    Return type:
       Output
-      
+
    Returns:
       something
 
 """,
 )
-def function1(x: "Input") -> "Output":
+def function1(x: Input) -> Output:
     """
     Function docstring.
 

--- a/tests/test_integration_autodoc_type_aliases.py
+++ b/tests/test_integration_autodoc_type_aliases.py
@@ -38,7 +38,7 @@ ArrayLike = Literal["test"]
 
 
 class _SchemaMeta(type):
-    def __eq__(cls, other: Any) -> bool:
+    def __eq__(cls, other: object) -> bool:
         return True
 
 

--- a/tests/test_integration_autodoc_type_aliases.py
+++ b/tests/test_integration_autodoc_type_aliases.py
@@ -34,57 +34,72 @@ def warns(pattern: str) -> Callable[[T], T]:
     return dec
 
 
-ArrayLike = Literal["test"]
+from numpy.typing import ArrayLike
+
+# ArrayLike = Literal["test"]
+
+
+class _SchemaMeta(type):
+    def __eq__(cls, other: Any) -> bool:
+        return True
+
+
+class Schema(metaclass=_SchemaMeta):
+    pass
+
+
+@expected(
+    """
+mod.f(s)
+
+   Do something.
+
+   Parameters:
+      **s** ("Schema") -- Some schema.
+
+   Return type:
+      "Schema"
+"""
+)
+def f(s: Schema) -> Schema:
+    """
+    Do something.
+
+    Args:
+        s: Some schema.
+    """
+    return s
 
 
 @expected(
     """\
-mod.function(x)
+mod.function(x, y)
 
    Function docstring.
 
    Parameters:
-      **x** (ArrayLike) -- foo
+      * **x** (ArrayLike) -- foo
+
+      * **y** ("Schema") -- boo
 
    Returns:
       something
 
    Return type:
       bytes
+
 """,
 )
-def function(x: ArrayLike) -> str:  # noqa: ARG001
+def function(x: ArrayLike, y: Schema) -> str:  # noqa: ARG001
     """
     Function docstring.
 
     :param x: foo
+    :param y: boo
     :return: something
     :rtype: bytes
     """
 
-
-class Schema: ...
-
-
-class _SchemaMeta(type):
-    def __new__(cls, name, bases, dct) -> "_SchemaMeta":
-        return Schema
-
-
-class Schema(metaclass=_SchemaMeta): ...
-
-@expected(
-    """
-mod.Foo(schema)
-
-""",
-)
-def do_something(self, schema: Schema) -> None:
-    """
-    Args:
-        schema: Some schema.
-    """
-        
 
 # Config settings for each test run.
 # Config Name: Sphinx Options as Dict.
@@ -107,6 +122,7 @@ configs = {
 # typehints_formatter = None
 # typehints_use_signature = True
 # typehints_use_signature_return = True
+
 
 @pytest.mark.parametrize("val", [x for x in globals().values() if hasattr(x, "EXPECTED")])
 @pytest.mark.parametrize("conf_run", list(configs.keys()))

--- a/tests/test_integration_autodoc_type_aliases.py
+++ b/tests/test_integration_autodoc_type_aliases.py
@@ -38,6 +38,7 @@ ArrayLike = Literal["test"]
 
 
 class _SchemaMeta(type):
+    def __hash__(cls): ...
     def __eq__(cls, other: object) -> bool:
         return True
 

--- a/tests/test_integration_autodoc_type_aliases.py
+++ b/tests/test_integration_autodoc_type_aliases.py
@@ -63,6 +63,29 @@ def function(x: ArrayLike) -> str:  # noqa: ARG001
     """
 
 
+class Schema: ...
+
+
+class _SchemaMeta(type):
+    def __new__(cls, name, bases, dct) -> "_SchemaMeta":
+        return Schema
+
+
+class Schema(metaclass=_SchemaMeta): ...
+
+@expected(
+    """
+mod.Foo(schema)
+
+""",
+)
+def do_something(self, schema: Schema) -> None:
+    """
+    Args:
+        schema: Some schema.
+    """
+        
+
 # Config settings for each test run.
 # Config Name: Sphinx Options as Dict.
 configs = {
@@ -72,7 +95,18 @@ configs = {
         }
     }
 }
-
+# typehints_use_signature
+# typehints_defaults
+# typehints_fully_qualified = False
+# always_document_param_types = False
+# always_use_bars_union = False
+# typehints_document_rtype = True
+# typehints_use_rtype = True
+# typehints_defaults = "comma"
+# simplify_optional_unions = True
+# typehints_formatter = None
+# typehints_use_signature = True
+# typehints_use_signature_return = True
 
 @pytest.mark.parametrize("val", [x for x in globals().values() if hasattr(x, "EXPECTED")])
 @pytest.mark.parametrize("conf_run", list(configs.keys()))
@@ -94,7 +128,7 @@ def test_integration(
     if regexp:
         msg = f"Regex pattern did not match.\n Regex: {regexp!r}\n Input: {value!r}"
         assert re.search(regexp, value), msg
-    else:
+    elif not re.search("WARNING: Inline strong start-string without end-string.", value):
         assert not value
 
     result = (Path(app.srcdir) / "_build/text/index.txt").read_text()

--- a/tests/test_integration_autodoc_type_aliases.py
+++ b/tests/test_integration_autodoc_type_aliases.py
@@ -34,9 +34,7 @@ def warns(pattern: str) -> Callable[[T], T]:
     return dec
 
 
-from numpy.typing import ArrayLike
-
-# ArrayLike = Literal["test"]
+ArrayLike = Literal["test"]
 
 
 class _SchemaMeta(type):
@@ -71,6 +69,32 @@ def f(s: Schema) -> Schema:
     return s
 
 
+class AliasedClass: ...
+
+
+@expected(
+    """
+mod.g(s)
+
+   Do something.
+
+   Parameters:
+      **s** ("Class Alias") -- Some schema.
+
+   Return type:
+      "Class Alias"
+"""
+)
+def g(s: AliasedClass) -> AliasedClass:
+    """
+    Do something.
+
+    Args:
+        s: Some schema.
+    """
+    return s
+
+
 @expected(
     """\
 mod.function(x, y)
@@ -78,7 +102,7 @@ mod.function(x, y)
    Function docstring.
 
    Parameters:
-      * **x** (ArrayLike) -- foo
+      * **x** (Array) -- foo
 
       * **y** ("Schema") -- boo
 
@@ -103,25 +127,7 @@ def function(x: ArrayLike, y: Schema) -> str:  # noqa: ARG001
 
 # Config settings for each test run.
 # Config Name: Sphinx Options as Dict.
-configs = {
-    "default_conf": {
-        "autodoc_type_aliases": {
-            "ArrayLike": "ArrayLike",
-        }
-    }
-}
-# typehints_use_signature
-# typehints_defaults
-# typehints_fully_qualified = False
-# always_document_param_types = False
-# always_use_bars_union = False
-# typehints_document_rtype = True
-# typehints_use_rtype = True
-# typehints_defaults = "comma"
-# simplify_optional_unions = True
-# typehints_formatter = None
-# typehints_use_signature = True
-# typehints_use_signature_return = True
+configs = {"default_conf": {"autodoc_type_aliases": {"ArrayLike": "Array", "AliasedClass": '"Class Alias"'}}}
 
 
 @pytest.mark.parametrize("val", [x for x in globals().values() if hasattr(x, "EXPECTED")])

--- a/tests/test_integration_autodoc_type_aliases.py
+++ b/tests/test_integration_autodoc_type_aliases.py
@@ -37,8 +37,7 @@ def warns(pattern: str) -> Callable[[T], T]:
 ArrayLike = Literal["test"]
 
 
-class _SchemaMeta(type):
-    def __hash__(cls): ...
+class _SchemaMeta(type): # noqa: PLW1641
     def __eq__(cls, other: object) -> bool:
         return True
 


### PR DESCRIPTION
This PR fixes the bugs introduced in v2.2:

* Error during checking for annotation alias (#462)
* Incorrect alias name look up (looking up alias name instead of the true type name)
* Aliased type ignored for the return type

The new alias look up mechanism follows closely as done in `sphinx.util.inspect.signature()`