### PR TITLE
Fix rendering when docstring starst with a directive

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -849,7 +849,7 @@ def get_insert_index(app: Sphinx, lines: list[str]) -> InsertIndexInfo | None:
         # at end. (I don't know of any input where this happens.)
         next_sibling = child.next_node(descend=False, siblings=True)
         line_no = node_line_no(next_sibling) if next_sibling else None
-        at = line_no - 2 if line_no else len(lines)
+        at = max(line_no - 2, 0) if line_no else len(lines)
         return InsertIndexInfo(insert_index=at, found_param=True)
 
     # 4. Insert before examples
@@ -857,7 +857,7 @@ def get_insert_index(app: Sphinx, lines: list[str]) -> InsertIndexInfo | None:
         if tag_name(child) in {"literal_block", "paragraph", "field_list"}:
             continue
         line_no = node_line_no(child)
-        at = line_no - 2 if line_no else len(lines)
+        at = max(line_no - 2, 0) if line_no else len(lines)
         return InsertIndexInfo(insert_index=at, found_directive=True)
 
     # 5. Otherwise, insert at end

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1342,6 +1342,24 @@ def docstring_with_multiline_note_after_params_epilog_replace(param: int) -> Non
     """
 
 
+@expected(
+    """
+    mod.docstring_with_see_also()
+
+       Return type:
+          "str"
+
+       See also: more info at <https://example.com>`_.
+
+    """
+)
+def docstring_with_see_also() -> str:
+    """
+    .. seealso:: more info at <https://example.com>`_.
+    """
+    return ""
+
+
 # Config settings for each test run.
 # Config Name: Sphinx Options as Dict.
 configs = {


### PR DESCRIPTION
We want to position our insertion before the directive but we incorrectly get a negative insertion line. This inserts at the end rather than at the beginning, and we fail to leave the correct empty line after the directive.

Resolves #467