### PR TITLE
Add module name rewrite configuration option

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -170,7 +170,7 @@ def format_internal_tuple(t: tuple[Any, ...], config: Config) -> str:
 
 
 def fixup_module_name(config: Config, module: str) -> str:
-    if config.typehints_fixup_module_name:
+    if getattr(config, "typehints_fixup_module_name", None):
         module = config.typehints_fixup_module_name(module)
 
     if module == "typing_extensions":

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -169,6 +169,18 @@ def format_internal_tuple(t: tuple[Any, ...], config: Config) -> str:
     return f"({', '.join(fmt)})"
 
 
+def fixup_module_name(config: Config, module: str) -> str:
+    if config.typehints_fixup_module_name:
+        module = config.typehints_fixup_module_name(module)
+
+    if module == "typing_extensions":
+        module = "typing"
+
+    if module == "_io":
+        module = "io"
+    return module
+
+
 def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901, PLR0911, PLR0912, PLR0915, PLR0914
     """
     Format the annotation.
@@ -204,13 +216,7 @@ def format_annotation(annotation: Any, config: Config) -> str:  # noqa: C901, PL
     except ValueError:
         return str(annotation).strip("'")
 
-    # Redirect all typing_extensions types to the stdlib typing module
-    if module == "typing_extensions":
-        module = "typing"
-
-    if module == "_io":
-        module = "io"
-
+    module = fixup_module_name(config, module)
     full_name = f"{module}.{class_name}" if module != "builtins" else class_name
     fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
     prefix = "" if fully_qualified or full_name == class_name else "~"
@@ -967,6 +973,7 @@ def setup(app: Sphinx) -> dict[str, bool]:
     app.add_config_value("typehints_formatter", None, "env")
     app.add_config_value("typehints_use_signature", False, "env")  # noqa: FBT003
     app.add_config_value("typehints_use_signature_return", False, "env")  # noqa: FBT003
+    app.add_config_value("typehints_fixup_module_name", None, "env")
     app.add_role("sphinx_autodoc_typehints_type", sphinx_autodoc_typehints_type_role)
     app.connect("env-before-read-docs", validate_config)  # config may be changed after “config-inited” event
     app.connect("autodoc-process-signature", process_signature)

--- a/tests/roots/test-dummy/export_module.py
+++ b/tests/roots/test-dummy/export_module.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from wrong_module_path import A, f
+
+__all__ = ["A", "f"]

--- a/tests/roots/test-dummy/future_annotations.rst
+++ b/tests/roots/test-dummy/future_annotations.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Dummy Module
 ============
 

--- a/tests/roots/test-dummy/simple.rst
+++ b/tests/roots/test-dummy/simple.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Simple Module
 =============
 

--- a/tests/roots/test-dummy/simple_default_role.rst
+++ b/tests/roots/test-dummy/simple_default_role.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Simple Module
 =============
 

--- a/tests/roots/test-dummy/simple_no_use_rtype.rst
+++ b/tests/roots/test-dummy/simple_no_use_rtype.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Simple Module
 =============
 

--- a/tests/roots/test-dummy/without_complete_typehints.rst
+++ b/tests/roots/test-dummy/without_complete_typehints.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Simple Module
 =============
 

--- a/tests/roots/test-dummy/wrong_module_path.py
+++ b/tests/roots/test-dummy/wrong_module_path.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class A:
+    pass
+
+
+def f() -> A:
+    pass

--- a/tests/roots/test-dummy/wrong_module_path.rst
+++ b/tests/roots/test-dummy/wrong_module_path.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+.. class:: export_module.A
+
+.. autofunction:: export_module.f

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1373,6 +1373,7 @@ def test_integration(
     (Path(app.srcdir) / "index.rst").write_text(template.format(val.__name__))
     app.config.__dict__.update(configs[conf_run])
     app.config.__dict__.update(val.OPTIONS)
+    app.config.nitpicky = True
     monkeypatch.setitem(sys.modules, "mod", sys.modules[__name__])
     app.build()
     assert "build succeeded" in status.getvalue()  # Build succeeded

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1373,7 +1373,6 @@ def test_integration(
     (Path(app.srcdir) / "index.rst").write_text(template.format(val.__name__))
     app.config.__dict__.update(configs[conf_run])
     app.config.__dict__.update(val.OPTIONS)
-    app.config.nitpicky = True
     monkeypatch.setitem(sys.modules, "mod", sys.modules[__name__])
     app.build()
     assert "build succeeded" in status.getvalue()  # Build succeeded

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -1133,9 +1133,7 @@ def test_wrong_module_path(app: SphinxTestApp, status: StringIO, warning: String
     app.config.master_doc = "wrong_module_path"  # create flag
     app.config.default_role = "literal"
     app.config.nitpicky = True
-    app.config.nitpick_ignore = {
-        ("py:data", "typing.Optional")
-    }
+    app.config.nitpick_ignore = {("py:data", "typing.Optional")}
 
     def fixup_module_name(mod: str) -> str:
         if not mod.startswith("wrong_module_path"):

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -1133,6 +1133,9 @@ def test_wrong_module_path(app: SphinxTestApp, status: StringIO, warning: String
     app.config.master_doc = "wrong_module_path"  # create flag
     app.config.default_role = "literal"
     app.config.nitpicky = True
+    app.config.nitpick_ignore = {
+        ("py:data", "typing.Optional")
+    }
 
     def fixup_module_name(mod: str) -> str:
         if not mod.startswith("wrong_module_path"):


### PR DESCRIPTION
This adds a configuration option that allows the user to rewrite module names if needed. Resolves #473. Note that we also rewrite the names of `_io` and `typing_extensions` internally. One benefit of this hook is that if other similar rewrites are needed, users will be able to immediately add them without having to patch sphinx_autodoc_typehints itself.

One disadvantage is that by default, having a function in the config prevents caching. I think this can be handled with the following slightly inelegant hack:

```py
class ModuleNameRewriteHook:
   version: int

   def __eq__(self, other):
      return type(self) == type(other) and self.version == other.version

   def __init__(self):
      self.version = 2

   def __call__(self, module):
      # logic here
      # Make sure to bump version if you edit this so that sphinx will rerun.
      return module

typehints_fixup_module_name = ModuleNameRewriteHook()
```

See https://github.com/sphinx-doc/sphinx/issues/12300.