### PR TITLE
Preserve type information from docstrings if no type annotation is present and parameter has default value.

### DIFF
--- a/tests/roots/test-dummy/dummy_module_without_complete_typehints.py
+++ b/tests/roots/test-dummy/dummy_module_without_complete_typehints.py
@@ -35,3 +35,14 @@ def function_with_defaults_and_some_typehints(x: int = 0, y=None) -> str:  # noq
     :param x: foo
     :param y: bar
     """
+
+
+def function_with_defaults_and_type_information_in_docstring(x, y=0) -> str:  # noqa: ANN001
+    """
+    Function docstring.
+
+    :type x: int
+    :type y: int
+    :param x: foo
+    :param y: bar
+    """

--- a/tests/roots/test-dummy/without_complete_typehints.rst
+++ b/tests/roots/test-dummy/without_complete_typehints.rst
@@ -7,3 +7,4 @@ Simple Module
 .. autofunction:: dummy_module_without_complete_typehints.function_with_some_defaults_and_some_typehints
 .. autofunction:: dummy_module_without_complete_typehints.function_with_some_defaults_and_more_typehints
 .. autofunction:: dummy_module_without_complete_typehints.function_with_defaults_and_some_typehints
+.. autofunction:: dummy_module_without_complete_typehints.function_with_defaults_and_type_information_in_docstring

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -1074,6 +1074,18 @@ def test_default_annotation_without_typehints(app: SphinxTestApp, status: String
 
        Return type:
           "str"
+
+    dummy_module_without_complete_typehints.function_with_defaults_and_type_information_in_docstring(x, y=0)
+
+       Function docstring.
+
+       Parameters:
+          * **x** (*int*) -- foo
+
+          * **y** (int, default: "0") -- bar
+
+       Return type:
+          "str"
     """
     assert text_contents == dedent(expected_contents)
 


### PR DESCRIPTION
Fixes #574.