### PR TITLE
Include metadata in type hints

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -268,6 +268,9 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
     if full_name == "typing.NewType":
         args_format = f"\\(``{annotation.__name__}``, {{}})"
         role = "class"
+    elif full_name == "typing.Annotated":
+        # By default we don't show metadata in Annotated
+        return format_annotation(annotation.__origin__, config, short_literals=short_literals)
     elif full_name in {"typing.TypeVar", "typing.ParamSpec"}:
         params = {k: getattr(annotation, f"__{k}__") for k in ("bound", "covariant", "contravariant")}
         params = {k: v for k, v in params.items() if v}
@@ -548,7 +551,7 @@ def _get_type_hint(
 ) -> dict[str, Any]:
     _resolve_type_guarded_imports(autodoc_mock_imports, obj)
     try:
-        result = get_type_hints(obj, None, localns)
+        result = get_type_hints(obj, None, localns, include_extras=True)
     except (AttributeError, TypeError, RecursionError) as exc:
         # TypeError - slot wrapper, PEP-563 when part of new syntax not supported
         # RecursionError - some recursive type definitions https://github.com/python/typing/issues/574

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -12,13 +12,16 @@ from textwrap import dedent, indent
 from types import EllipsisType, FrameType, FunctionType, ModuleType, NotImplementedType, TracebackType
 from typing import (  # noqa: UP035
     IO,
+    Annotated,
     Any,
     AnyStr,
     Dict,
     Generic,
     List,
     NewType,
+    NotRequired,
     Optional,
+    Required,
     Tuple,
     Type,
     TypeVar,
@@ -394,6 +397,9 @@ _CASES = [
         r":py:data:`~typing.Tuple`\ \[:py:class:`int`, :py:data:`...<Ellipsis>`]",
         id="Tuple-p-Ellipsis",
     ),
+    pytest.param(Annotated[int, "metadata"], r":py:class:`int`", id="Annotated-metadata"),
+    pytest.param(Required[int], r":py:class:`~typing.Required`\ \[:py:class:`int`]", id="Required"),
+    pytest.param(NotRequired[int], r":py:class:`~typing.NotRequired`\ \[:py:class:`int`]", id="NotRequired"),
 ]
 
 


### PR DESCRIPTION
By default, the `get_type_hints` function strips the metadata. For Python < 3.13, it replaces `Annotated[T, ...]` with plain `T`, and for Python >= 3.13, it replaces `Required[T]`, `NotRequired[T]`, `ReadOnly[T]` with plain `T`.

Here we include the metadata for two purposes:
1. Correctly format `Required[T]` etc. in Python 3.13+
2. Include metadata in `Annotated[T, ...]` so that users can add custom logics based on them using `typehints_formatter`

Related issue but not the same:
- #149