### PR TITLE
🐛 fix(types): resolve PEP 695 type params in annotations

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -552,10 +552,29 @@ def _resolve_type_guarded_imports(autodoc_mock_imports: list[str], obj: Any) -> 
             _execute_guarded_code(autodoc_mock_imports, obj, module_code)
 
 
+def _add_type_params_to_localns(
+    obj: Any, localns: dict[Any, MyTypeAliasForwardRef]
+) -> dict[Any, MyTypeAliasForwardRef]:
+    if type_params := getattr(obj, "__type_params__", None):
+        localns = {**localns, **{p.__name__: p for p in type_params}}
+    qualname = getattr(obj, "__qualname__", "") or ""
+    parts = qualname.rsplit(".", 1)
+    if len(parts) > 1:
+        parent_name = parts[0]
+        ns = getattr(obj, "__globals__", None)
+        if ns is None:
+            module = inspect.getmodule(obj)
+            ns = vars(module) if module else None
+        if ns and (parent := ns.get(parent_name)) and (parent_params := getattr(parent, "__type_params__", None)):
+            localns = {**localns, **{p.__name__: p for p in parent_params}}
+    return localns
+
+
 def _get_type_hint(
     autodoc_mock_imports: list[str], name: str, obj: Any, localns: dict[Any, MyTypeAliasForwardRef]
 ) -> dict[str, Any]:
     _resolve_type_guarded_imports(autodoc_mock_imports, obj)
+    localns = _add_type_params_to_localns(obj, localns)
     try:
         result = get_type_hints(obj, None, localns, include_extras=True)
     except (AttributeError, TypeError, RecursionError) as exc:

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from io import StringIO
+
+    from sphinx.testing.util import SphinxTestApp
+
+_mod_pep695 = types.ModuleType("_mod_pep695")
+_mod_pep695.__file__ = __file__
+exec(  # noqa: S102
+    dedent("""\
+    from __future__ import annotations
+
+    class Foo[T]:
+        \"\"\"A generic class.\"\"\"
+
+        def __init__(self, thing: T) -> None:
+            \"\"\"Init.
+
+            :param thing: the thing
+            \"\"\"
+
+        def get(self) -> T:
+            \"\"\"Get the thing.
+
+            :return: the thing
+            \"\"\"
+            ...
+
+    class Multi[K, V]:
+        \"\"\"A class with multiple type params.\"\"\"
+
+        def lookup(self, key: K) -> V:
+            \"\"\"Look up.
+
+            :param key: the key
+            \"\"\"
+            ...
+
+    def identity[U](x: U) -> U:
+        \"\"\"Identity function.
+
+        :param x: input
+        \"\"\"
+        return x
+    """),
+    _mod_pep695.__dict__,
+)
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_class_type_params(
+    app: SphinxTestApp, status: StringIO, warning: StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        Test
+        ====
+
+        .. autoclass:: mod.Foo
+           :members:
+    """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert "Cannot resolve forward reference" not in warning.getvalue()
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_class_multiple_type_params(
+    app: SphinxTestApp, status: StringIO, warning: StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        Test
+        ====
+
+        .. autoclass:: mod.Multi
+           :members:
+    """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert "Cannot resolve forward reference" not in warning.getvalue()
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_function_type_params(
+    app: SphinxTestApp, status: StringIO, warning: StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        Test
+        ====
+
+        .. autofunction:: mod.identity
+    """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert "Cannot resolve forward reference" not in warning.getvalue()


### PR DESCRIPTION
Using PEP 695 type parameter syntax (`class Foo[T]`, `def bar[U](x: U)`) combined with `from __future__ import annotations` produces spurious `Cannot resolve forward reference: name 'T' is not defined` warnings. 🔥 This blocks adoption of the modern generic syntax that became standard in Python 3.12+.

The root cause is that `get_type_hints()` needs type parameters in its local namespace to resolve stringified annotations, but PEP 695 stores them in `__type_params__` rather than in the class or module namespace. The fix populates `localns` with these type parameters before resolution. For methods like `__init__`, it also walks up to the parent class via `__qualname__` and `__globals__` to pick up class-level type parameters.

Fixes #580. Also related to #381 and #186 which are variants of the same forward reference resolution gap.