### PR TITLE
fix: separate injected :rtype: from preceding paragraph

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -1039,10 +1039,11 @@ def _inject_rtype(  # noqa: C901, PLR0913, PLR0917
     if r.found_param and insert_index < len(lines) and lines[insert_index].strip():
         insert_index -= 1
 
-    if insert_index == len(lines) and not r.found_param:
+    if insert_index > 0 and insert_index <= len(lines) and lines[insert_index - 1].strip():
         # ensure that :rtype: doesn't get joined with a paragraph of text
-        lines.append("")
+        lines.insert(insert_index, "")
         insert_index += 1
+
     if app.config.typehints_use_rtype or not r.found_return:
         line = f":rtype: {formatted_annotation}"
         lines.insert(insert_index, line)

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -35,6 +35,7 @@ from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.ext.autodoc import Options
 
+import sphinx_autodoc_typehints as sat
 from sphinx_autodoc_typehints import (
     _resolve_type_guarded_imports,
     backfill_type_hints,
@@ -1216,3 +1217,57 @@ def test_wrong_module_path(app: SphinxTestApp, status: StringIO, warning: String
 
     assert "build succeeded" in status.getvalue()  # Build succeeded
     assert not warning.getvalue().strip()
+
+
+def test_inject_rtype_inserts_blank_line_before_rtype(monkeypatch: pytest.MonkeyPatch) -> None:
+    def sample() -> str:
+        return "ok"
+
+    config = create_autospec(
+        Config,
+        typehints_document_rtype=True,
+        typehints_document_rtype_none=True,
+        typehints_use_rtype=True,
+        python_display_short_literal_types=False,
+    )
+    app: Sphinx = create_autospec(Sphinx, config=config)
+
+    monkeypatch.setattr(
+        sat,
+        "get_insert_index",
+        lambda _app, _lines: sat.InsertIndexInfo(insert_index=1, found_directive=True),
+    )
+    monkeypatch.setattr(sat, "format_annotation", lambda *_args, **_kwargs: "str")
+    monkeypatch.setattr(sat, "add_type_css_class", lambda value: value)
+
+    lines = ["A paragraph.", ".. note:: hi"]
+    sat._inject_rtype({"return": str}, sample, app, "function", "sample", lines)  # noqa: SLF001
+
+    assert lines == ["A paragraph.", "", ":rtype: str", "", ".. note:: hi"]
+
+
+def test_inject_rtype_does_not_add_extra_blank_line(monkeypatch: pytest.MonkeyPatch) -> None:
+    def sample() -> str:
+        return "ok"
+
+    config = create_autospec(
+        Config,
+        typehints_document_rtype=True,
+        typehints_document_rtype_none=True,
+        typehints_use_rtype=True,
+        python_display_short_literal_types=False,
+    )
+    app: Sphinx = create_autospec(Sphinx, config=config)
+
+    monkeypatch.setattr(
+        sat,
+        "get_insert_index",
+        lambda _app, _lines: sat.InsertIndexInfo(insert_index=1),
+    )
+    monkeypatch.setattr(sat, "format_annotation", lambda *_args, **_kwargs: "str")
+    monkeypatch.setattr(sat, "add_type_css_class", lambda value: value)
+
+    lines = ["", ""]
+    sat._inject_rtype({"return": str}, sample, app, "function", "sample", lines)  # noqa: SLF001
+
+    assert lines == ["", ":rtype: str", ""]


### PR DESCRIPTION
## Summary
Fixes `:rtype:` insertion so it always gets separated from preceding paragraph text.

Issue #431 reports cases where `:rtype:` is injected immediately after paragraph content without a blank line, which makes rendering incorrect.

## What changed
- In `_inject_rtype(...)`, before inserting `:rtype:`, add a blank line when the line immediately before insertion is non-empty.
- Kept the rest of insertion behavior intact (including directive spacing behavior).

## Tests
Added two focused tests:
- `test_inject_rtype_inserts_blank_line_before_rtype`
- `test_inject_rtype_does_not_add_extra_blank_line`

These cover the regression case and ensure no extra blank line is added when one already exists.

Fixes #431
