### PR TITLE
🐛 fix(rtype): skip Return type for generators with Yields

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import collections.abc
 import importlib
 import inspect
 import re
@@ -986,7 +987,7 @@ def get_insert_index(app: Sphinx, lines: list[str]) -> InsertIndexInfo | None:
     return InsertIndexInfo(insert_index=len(lines))
 
 
-def _inject_rtype(  # noqa: C901, PLR0913, PLR0917
+def _inject_rtype(  # noqa: C901, PLR0911, PLR0913, PLR0917
     type_hints: dict[str, Any],
     original_obj: Any,
     app: Sphinx,
@@ -1001,6 +1002,8 @@ def _inject_rtype(  # noqa: C901, PLR0913, PLR0917
     if not app.config.typehints_document_rtype:
         return
     if not app.config.typehints_document_rtype_none and type_hints["return"] is types.NoneType:
+        return
+    if _has_yields_section(lines) and _is_generator_type(type_hints["return"]):
         return
 
     r = get_insert_index(app, lines)
@@ -1032,6 +1035,23 @@ def _inject_rtype(  # noqa: C901, PLR0913, PLR0917
     else:
         line = lines[insert_index]
         lines[insert_index] = f":return: {formatted_annotation} --{line[line.find(' ') :]}"
+
+
+_GENERATOR_TYPES = frozenset({
+    collections.abc.Generator,
+    collections.abc.Iterator,
+    collections.abc.AsyncGenerator,
+    collections.abc.AsyncIterator,
+})
+
+
+def _is_generator_type(annotation: Any) -> bool:
+    origin = getattr(annotation, "__origin__", None)
+    return origin in _GENERATOR_TYPES or annotation in _GENERATOR_TYPES
+
+
+def _has_yields_section(lines: list[str]) -> bool:
+    return any(line.lstrip().startswith((":Yields:", ":yields:", ":yield:")) for line in lines)
 
 
 def validate_config(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:  # noqa: ARG001

--- a/tests/test_generator_yields.py
+++ b/tests/test_generator_yields.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, AsyncIterator, Generator, Iterator
+    from io import StringIO
+
+    from sphinx.testing.util import SphinxTestApp
+
+
+class GenClass:
+    """A class with generators."""
+
+    def gen_method(  # noqa: PLR6301
+        self,
+        arg1: int | None = None,  # noqa: ARG002
+    ) -> Generator[tuple[str, ...], None, None]:
+        """Summary.
+
+        Args:
+            arg1: argument 1
+
+        Yields:
+            strings of things
+        """
+        yield ("test",)
+
+    def iter_method(self) -> Iterator[int]:  # noqa: PLR6301
+        """Summary.
+
+        Yields:
+            integers
+        """
+        yield 1
+
+    async def async_gen_method(self) -> AsyncGenerator[str, None]:  # noqa: PLR6301
+        """Summary.
+
+        Yields:
+            strings
+        """
+        yield "test"
+
+    async def async_iter_method(self) -> AsyncIterator[int]:  # noqa: PLR6301
+        """Summary.
+
+        Yields:
+            integers
+        """
+        yield 1
+
+    def no_yields_method(self) -> Generator[int, None, None]:  # noqa: PLR6301
+        """Summary without yields section."""
+        yield 1
+
+
+def _extract_section(text: str, method_name: str) -> str:
+    pattern = rf"({method_name}\(\).*?)(?=(?:async\s+)?\w+\(\)|$)"
+    if match := re.search(pattern, text, re.DOTALL):
+        return match.group(1)
+    msg = f"Method {method_name} not found in output"
+    raise ValueError(msg)
+
+
+def _build_genclass(app: SphinxTestApp, monkeypatch: pytest.MonkeyPatch) -> str:
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        Test
+        ====
+
+        .. autoclass:: mod.GenClass
+           :members:
+    """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", sys.modules[__name__])
+    app.build()
+    return (Path(app.srcdir) / "_build/text/index.txt").read_text()
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_generator_no_duplicate_return_type(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    text = _build_genclass(app, monkeypatch)
+    assert "build succeeded" in status.getvalue()
+
+    for method in ("gen_method", "iter_method", "async_gen_method", "async_iter_method"):
+        section = _extract_section(text, method)
+        assert "Yields" in section, f"{method} missing Yields"
+        assert "Return type" not in section, f"{method} has unexpected Return type"
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_generator_without_yields_keeps_rtype(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    text = _build_genclass(app, monkeypatch)
+    assert "build succeeded" in status.getvalue()
+
+    section = _extract_section(text, "no_yields_method")
+    assert "Return type" in section


### PR DESCRIPTION
Generator and iterator methods that have a `Yields:` section in their docstring were getting both a "Yields:" and a "Return type:" section in the rendered output. 🔍 This produced confusing duplicate type information since the yield type and the return annotation (`Generator[X, None, None]`) convey the same thing.

The fix detects when the docstring already contains a processed yields directive (`:Yields:`) and the return annotation is a generator or iterator type (`Generator`, `Iterator`, `AsyncGenerator`, `AsyncIterator`), skipping the return type injection in that case. Generators without a `Yields:` section still get their `Return type:` preserved, since that's the only place their type information would appear.

Fixes #419.