### PR TITLE
🐛 fix(guard): silence ImportError for third-party guards

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -515,22 +515,27 @@ def _execute_guarded_code(autodoc_mock_imports: list[str], obj: Any, module_code
     for _, part in _TYPE_GUARD_IMPORT_RE.findall(module_code):
         guarded_code = textwrap.dedent(part)
         try:
-            try:
-                with mock(autodoc_mock_imports):
-                    exec(guarded_code, getattr(obj, "__globals__", obj.__dict__))  # noqa: S102
-            except ImportError as exc:
-                # ImportError might have occurred because the module has guarded code as well,
-                # so we recurse on the module.
-                if exc.name:
-                    _resolve_type_guarded_imports(autodoc_mock_imports, importlib.import_module(exc.name))
-
-                    # Retry the guarded code and see if it works now after resolving all nested type guards.
-                    with mock(autodoc_mock_imports):
-                        exec(guarded_code, getattr(obj, "__globals__", obj.__dict__))  # noqa: S102
+            _run_guarded_import(autodoc_mock_imports, obj, guarded_code)
         except Exception as exc:  # noqa: BLE001
             _LOGGER.warning(
                 "Failed guarded type import with %r", exc, type="sphinx_autodoc_typehints", subtype="guarded_import"
             )
+
+
+def _run_guarded_import(autodoc_mock_imports: list[str], obj: Any, guarded_code: str) -> None:
+    ns = getattr(obj, "__globals__", obj.__dict__)
+    try:
+        with mock(autodoc_mock_imports):
+            exec(guarded_code, ns)  # noqa: S102
+    except ImportError as exc:
+        if not exc.name:
+            return
+        _resolve_type_guarded_imports(autodoc_mock_imports, importlib.import_module(exc.name))
+        try:
+            with mock(autodoc_mock_imports):
+                exec(guarded_code, ns)  # noqa: S102
+        except ImportError:
+            pass  # third-party internal import that doesn't exist at runtime
 
 
 def _resolve_type_guarded_imports(autodoc_mock_imports: list[str], obj: Any) -> None:

--- a/tests/test_guarded_import.py
+++ b/tests/test_guarded_import.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from io import StringIO
+
+    from sphinx.testing.util import SphinxTestApp
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_guarded_import_missing_name_no_warning(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_mod = types.ModuleType("target_mod")
+    target_mod.__file__ = "/fake/target_mod.py"
+    target_mod.existing_name = "value"
+
+    source = dedent("""\
+    from __future__ import annotations
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from target_mod import nonexistent_name
+
+    def func(x: int) -> int:
+        '''Do something.
+
+        Args:
+            x: a number
+        '''
+        return x
+    """)
+    user_mod = types.ModuleType("user_mod")
+    user_mod.__file__ = "/fake/user_mod.py"
+    exec(compile(source, "/fake/user_mod.py", "exec"), user_mod.__dict__)  # noqa: S102
+
+    monkeypatch.setitem(sys.modules, "target_mod", target_mod)
+    monkeypatch.setitem(sys.modules, "user_mod", user_mod)
+
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        Test
+        ====
+
+        .. autofunction:: user_mod.func
+    """)
+    )
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert "Failed guarded type import" not in warning.getvalue()

--- a/tests/test_guarded_import.py
+++ b/tests/test_guarded_import.py
@@ -23,7 +23,6 @@ def test_guarded_import_missing_name_no_warning(
 ) -> None:
     target_mod = types.ModuleType("target_mod")
     target_mod.__file__ = "/fake/target_mod.py"
-    target_mod.existing_name = "value"
 
     source = dedent("""\
     from __future__ import annotations

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -950,11 +950,7 @@ def test_resolve_typing_guard_imports(app: SphinxTestApp, status: StringIO, warn
     app.build()
     out = status.getvalue()
     assert "build succeeded" in out
-    err = warning.getvalue()
-    r = re.compile(r"WARNING: Failed guarded type import")
-    assert len(r.findall(err)) == 1
-    pat = r'WARNING: Failed guarded type import with ImportError\("cannot import name \'missing\' from \'functools\''
-    assert re.search(pat, err)
+    assert "Failed guarded type import" not in warning.getvalue()
 
 
 @pytest.mark.sphinx("text", testroot="resolve-typing-guard-tmp")


### PR DESCRIPTION
Projects that depend on libraries like `urllib3` were getting spurious `WARNING: Failed guarded type import with ImportError(...)` messages during documentation builds. 🔍 These warnings originate from third-party `TYPE_CHECKING`-guarded imports that reference internal names renamed or removed across versions — something users have no control over and cannot fix.

The guarded import resolver already attempts to recurse into the failing module and retry the import. When the retry still fails with `ImportError`, it now silently moves on instead of escalating to a user-visible warning. Non-`ImportError` exceptions (indicating genuinely broken code rather than third-party internals) still produce warnings as before.

This is a behavioral change: `ImportError` from guarded imports that persist after recursive resolution will no longer appear in build output. Users who were filtering or ignoring these warnings can remove those workarounds.

Fixes #610.