### PR TITLE
fix: preserve links for unevaluated type aliases in unions

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -238,7 +238,7 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
         return format_internal_tuple(annotation, config)
 
     if isinstance(annotation, TypeAliasForwardRef):
-        return annotation.name
+        return f":py:data:`{annotation.name}`"
 
     try:
         module = get_annotation_module(annotation)

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -35,6 +35,7 @@ from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.ext.autodoc import Options
 
+import sphinx_autodoc_typehints as sat
 from sphinx_autodoc_typehints import (
     _resolve_type_guarded_imports,
     backfill_type_hints,
@@ -478,6 +479,20 @@ def test_always_use_bars_union(annotation: str, expected_result: str) -> None:
     conf = create_autospec(Config, always_use_bars_union=True)
     result = format_annotation(eval(annotation), conf)  # noqa: S307
     assert result == expected_result
+
+
+def test_format_annotation_type_alias_forward_ref() -> None:
+    conf = create_autospec(Config)
+    annotation = sat.MyTypeAliasForwardRef("_Operation")
+
+    assert format_annotation(annotation, conf) == ":py:data:`_Operation`"
+
+
+def test_format_annotation_type_alias_forward_ref_in_union() -> None:
+    conf = create_autospec(Config, always_use_bars_union=True)
+    annotation = sat.MyTypeAliasForwardRef("_Operation") | list[sat.MyTypeAliasForwardRef("_Operation")]
+
+    assert format_annotation(annotation, conf) == r":py:data:`_Operation` | :py:class:`list`\ \[:py:data:`_Operation`]"
 
 
 @pytest.mark.parametrize("library", [typing, typing_extensions], ids=["typing", "typing_extensions"])


### PR DESCRIPTION
## Summary
Fix missing links for unevaluated type aliases inside unions.

I picked #481 (smaller + still reproducible). #420 did not reproduce on current `main` in a quick check.

## Repro
When formatting a type alias forward ref in a union, the alias name was rendered as plain text (no cross-reference), e.g. `_Operation | list[_Operation]`.

## Fix
- In `format_annotation(...)`, render `TypeAliasForwardRef` as a `:py:data:` cross-reference instead of plain text.
- This preserves links for aliases even when they appear inside unions.

## Tests
Added focused unit tests:
- `test_format_annotation_type_alias_forward_ref`
- `test_format_annotation_type_alias_forward_ref_in_union`

## Validation
- `ruff check src/sphinx_autodoc_typehints/__init__.py tests/test_sphinx_autodoc_typehints.py`
- `pytest -q tests/test_sphinx_autodoc_typehints.py -k "type_alias_forward_ref"`

Fixes #481
