### PR TITLE
🐛 fix(rtype): separate rtype from preceding text

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -1048,7 +1048,6 @@ def _inject_rtype(  # noqa: C901, PLR0911, PLR0913, PLR0917
         insert_index -= 1
 
     if insert_index > 0 and insert_index <= len(lines) and lines[insert_index - 1].strip():
-        # ensure that :rtype: doesn't get joined with a paragraph of text
         lines.insert(insert_index, "")
         insert_index += 1
 

--- a/tests/test_rtype_separation.py
+++ b/tests/test_rtype_separation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from io import StringIO
+
+    from sphinx.testing.util import SphinxTestApp
+
+
+def func_with_note(x: int) -> str:
+    """Do something.
+
+    .. note::
+
+        This is a note about the function.
+    """
+    return str(x)
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_rtype_separated_from_preceding_paragraph(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        Test
+        ====
+
+        .. autofunction:: mod.func_with_note
+    """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", sys.modules[__name__])
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    text = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    assert "Return type" in text
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if "Return type" in line:
+            assert i > 0, "Return type should not be the first line"
+            assert not lines[i - 1].strip() or lines[i - 1].lstrip().startswith("Return type"), (
+                f"Return type should be preceded by a blank line, got: {lines[i - 1]!r}"
+            )


### PR DESCRIPTION
The `:rtype:` directive was sometimes rendered merged into the preceding paragraph in the final HTML output, producing garbled documentation. This happened when a docstring had content like `.. note::` or other directives before the insertion point but no parameter section, because the blank-line separator was only added when `:rtype:` was inserted at the very end of the docstring.

The fix generalizes the separator logic to check whether the line immediately before the insertion point is non-empty, and inserts a blank line if so. This covers all insertion positions — end of docstring, after params, or between content blocks — ensuring `:rtype:` always starts its own paragraph.

Fixes #431.