### PR TITLE
🐛 fix(sig): prevent KeyError in method lookup

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -444,7 +444,7 @@ def process_signature(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0917
             if method_name.startswith("__") and not method_name.endswith("__"):
                 # when method starts with double underscore Python applies mangling -> prepend the class name
                 method_name = f"_{obj.__qualname__.split('.')[-2]}{method_name}"
-            method_object = outer.__dict__[method_name] if outer else obj
+            method_object = outer.__dict__.get(method_name, obj) if outer else obj
             if not isinstance(method_object, classmethod | staticmethod):
                 start = 1
 

--- a/tests/test_method_lookup.py
+++ b/tests/test_method_lookup.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from io import StringIO
+
+    from sphinx.testing.util import SphinxTestApp
+
+
+class MyClass:
+    """A class with a property."""
+
+    @property
+    def n_unique_nonzero(self) -> int:
+        """Number of unique nonzero elements."""
+        return 0
+
+    def regular_method(self, x: int) -> int:  # noqa: PLR6301
+        """Do something.
+
+        Args:
+            x: a number
+        """
+        return x
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_method_lookup_does_not_crash(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        Test
+        ====
+
+        .. autoclass:: mod.MyClass
+           :members:
+    """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", sys.modules[__name__])
+    app.build()
+    assert "build succeeded" in status.getvalue()


### PR DESCRIPTION
When autodoc encounters a method whose name doesn't appear in the parent class's `__dict__` — for example properties or dynamically generated methods — the build crashes with a `KeyError` during signature processing. This was reported with the `quemb` project where a property named `n_unique_nonzero` triggered the crash (#532).

The fix replaces the direct dictionary lookup with `dict.get()`, falling back to the original object. This preserves the `classmethod`/`staticmethod` detection logic while preventing the crash for methods that aren't found in `__dict__` under the expected name.

Fixes #532.