### PR TITLE
🐛 fix(parser): neutralize directive side-effects

### DIFF
--- a/src/sphinx_autodoc_typehints/_parser.py
+++ b/src/sphinx_autodoc_typehints/_parser.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
+from docutils.parsers.rst import Directive, directives
 from docutils.utils import new_document
 from sphinx.parsers import RSTParser
 from sphinx.util.docutils import sphinx_domains
 
 if TYPE_CHECKING:
     import optparse
+    from collections.abc import Iterator
 
     from docutils import nodes
     from docutils.frontend import Values
@@ -22,10 +26,40 @@ class _RstSnippetParser(RSTParser):
         """Override to skip processing rst_epilog/rst_prolog for typing."""
 
 
+class _NoOpDirective(Directive):
+    has_content = True
+    optional_arguments = 99
+    final_argument_whitespace = True
+
+    def run(self) -> list[nodes.Node]:  # noqa: PLR6301
+        return []
+
+
+_BUILTIN_DIRECTIVES = frozenset(directives._directive_registry)  # noqa: SLF001
+
+
+@contextmanager
+def _safe_directives() -> Iterator[None]:
+    original = directives.directive
+
+    def _safe_lookup(
+        directive_name: str,
+        language_module: object,
+        document: object,
+    ) -> tuple[type[Directive] | None, list[str]]:
+        cls, messages = original(directive_name, language_module, document)
+        if cls is not None and directive_name not in _BUILTIN_DIRECTIVES:
+            return _NoOpDirective, messages
+        return cls, messages
+
+    with patch.object(directives, "directive", _safe_lookup):
+        yield
+
+
 def parse(inputstr: str, settings: Values | optparse.Values) -> nodes.document:
     """Parse inputstr and return a docutils document."""
     doc = new_document("", settings=settings)  # ty: ignore[invalid-argument-type]
-    with sphinx_domains(settings.env):
+    with sphinx_domains(settings.env), _safe_directives():
         parser = _RstSnippetParser()
         parser.parse(inputstr, doc)
     return doc


### PR DESCRIPTION
Extensions like [sphinx-needs](https://sphinx-needs.readthedocs.io/) register unique identifiers when their directives execute. Since the snippet parser processes docstrings a second time to locate field lists for `:rtype:` insertion, those directive handlers run twice — once during our analysis and once during the real Sphinx build. This causes duplicate ID errors and other problems for any extension with non-idempotent side-effects.

The fix intercepts directive lookup during snippet parsing and replaces any non-builtin directive with a no-op handler that returns an empty node list. 🛡️ Builtin docutils directives (code-block, rubric, seealso, etc.) still execute normally since they're needed for correct document tree structure. Only third-party directives registered by extensions are neutralized.

This is a targeted fix that avoids the more invasive alternative of replacing the RST parser with regex-based field detection. The document tree structure is preserved for the existing `get_insert_index()` logic, while side-effects from extension directives are eliminated.

Fixes #510.