### PR TITLE
🐛 fix(annotations): show NewType as alias name with supertype

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -267,12 +267,16 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
 
     # Some types require special handling
     if full_name == "typing.NewType":
-        args_format = f"\\(``{annotation.__name__}``, {{}})"
-        role = "obj"
-    elif full_name == "typing.Annotated":
+        newtype_module = fixup_module_name(config, getattr(annotation, "__module__", ""))
+        newtype_name = annotation.__name__
+        newtype_qualified = f"{newtype_module}.{newtype_name}" if newtype_module else newtype_name
+        newtype_prefix = "" if fully_qualified or not newtype_module else "~"
+        supertype = format_annotation(annotation.__supertype__, config, short_literals=short_literals)
+        return f":py:class:`{newtype_prefix}{newtype_qualified}` ({supertype})"
+    if full_name == "typing.Annotated":
         # By default we don't show metadata in Annotated
         return format_annotation(annotation.__origin__, config, short_literals=short_literals)
-    elif full_name in {"typing.TypeVar", "typing.ParamSpec"}:
+    if full_name in {"typing.TypeVar", "typing.ParamSpec"}:
         params = {k: getattr(annotation, f"__{k}__") for k in ("bound", "covariant", "contravariant")}
         params = {k: v for k, v in params.items() if v}
         if "bound" in params:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1292,10 +1292,10 @@ def has_typevar[T](param: T) -> T:
        Do something.
 
        Parameters:
-          **param** ("NewType"("W", "str")) -- A parameter.
+          **param** ("W" ("str")) -- A parameter.
 
        Return type:
-          "NewType"("W", "str")
+          "W" ("str")
 
     """,
 )

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -356,7 +356,7 @@ _CASES = [
     pytest.param(D, f":py:class:`~{__name__}.D`", id="D"),
     pytest.param(E, f":py:class:`~{__name__}.E`", id="E"),
     pytest.param(E[int], rf":py:class:`~{__name__}.E`\ \[:py:class:`int`]", id="E-int"),
-    pytest.param(W, r":py:obj:`~typing.NewType`\ \(``W``, :py:class:`str`)", id="W"),
+    pytest.param(W, f":py:class:`~{__name__}.W` (:py:class:`str`)", id="W"),
     pytest.param(T, r":py:class:`~typing.TypeVar`\ \(``T``)", id="T"),
     pytest.param(U_co, r":py:class:`~typing.TypeVar`\ \(``U_co``, covariant=True)", id="U-co"),
     pytest.param(V_contra, r":py:class:`~typing.TypeVar`\ \(``V_contra``, contravariant=True)", id="V-contra"),


### PR DESCRIPTION
When users define a `NewType` alias like `UserId = NewType("UserId", int)`, the documentation should show `UserId (int)` — not `NewType("UserId", int)`. The old rendering exposed the implementation detail of how the alias was created, which is noisy and buries the alias name that users actually care about. This is one of the most commented-on issues in the project (11 comments on #132).

The fix renders `NewType` annotations as a `:py:class:` cross-reference to the alias name followed by the supertype in parentheses. For example `W = NewType("W", str)` now renders as `W (str)` instead of `NewType("W", str)`. 🔗 This preserves the supertype information while keeping the alias name prominent, and enables intersphinx linking when the alias is documented with `.. py:class::` or `.. py:type::`.

The only behavioral change is in how `NewType` appears in generated docs. No configuration changes are needed.

Closes #132