### PR TITLE
✨ feat(signatures): enable overload signature display

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -808,7 +808,11 @@ def process_docstring(  # noqa: PLR0913, PLR0917
 
 
 def _inject_overload_signatures(  # noqa: C901
-    app: Sphinx, what: str, name: str, obj: Any, lines: list[str]  # noqa: ARG001
+    app: Sphinx,
+    what: str,
+    name: str,
+    obj: Any,
+    lines: list[str],
 ) -> bool:
     if what not in {"function", "method"}:
         return False

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -26,7 +26,7 @@ from sphinx.util.inspect import TypeAliasForwardRef, stringify_signature
 from sphinx.util.inspect import signature as sphinx_signature
 
 from ._parser import _RstSnippetParser, parse
-from .patches import install_patches
+from .patches import _OVERLOADS_CACHE, install_patches
 from .version import __version__
 
 if TYPE_CHECKING:
@@ -801,9 +801,60 @@ def process_docstring(  # noqa: PLR0913, PLR0917
     type_hints = get_all_type_hints(app.config.autodoc_mock_imports, obj, name, localns)
     app.config._annotation_globals = getattr(obj, "__globals__", {})  # noqa: SLF001
     try:
-        _inject_types_to_docstring(type_hints, signature, original_obj, app, what, name, lines)
+        has_overloads = _inject_overload_signatures(app, what, name, obj, lines)
+        _inject_types_to_docstring(type_hints, signature, original_obj, app, what, name, lines, has_overloads)
     finally:
         delattr(app.config, "_annotation_globals")
+
+
+def _inject_overload_signatures(  # noqa: C901
+    app: Sphinx, what: str, name: str, obj: Any, lines: list[str]  # noqa: ARG001
+) -> bool:
+    if what not in {"function", "method"}:
+        return False
+
+    module_name = getattr(obj, "__module__", None)
+    if not module_name or module_name not in _OVERLOADS_CACHE:
+        return False
+
+    qualname = getattr(obj, "__qualname__", None)
+    if not qualname:
+        return False
+
+    overloads = _OVERLOADS_CACHE[module_name].get(qualname)
+    if not overloads:
+        return False
+
+    short_literals = app.config.python_display_short_literal_types
+    overload_lines = [":Overloads:"]
+    for overload_sig in overloads:
+        params = []
+        for param_name, param in overload_sig.parameters.items():
+            if param.annotation != inspect.Parameter.empty:
+                formatted_type = format_annotation(param.annotation, app.config, short_literals=short_literals)
+                formatted_type = add_type_css_class(formatted_type)
+                params.append(f"**{param_name}** ({formatted_type})")
+            else:
+                params.append(f"**{param_name}**")
+
+        return_annotation = ""
+        if overload_sig.return_annotation != inspect.Signature.empty:
+            formatted_return = format_annotation(
+                overload_sig.return_annotation, app.config, short_literals=short_literals
+            )
+            formatted_return = add_type_css_class(formatted_return)
+            return_annotation = f" \u2192 {formatted_return}"
+
+        sig_line = f"   * {', '.join(params)}{return_annotation}"
+        overload_lines.append(sig_line)
+
+    if len(overload_lines) > 1:
+        overload_lines.append("")
+        for line in reversed(overload_lines):
+            lines.insert(0, line)
+        return True
+
+    return False
 
 
 def _get_sphinx_line_keyword_and_argument(line: str) -> tuple[str, str | None] | None:
@@ -855,10 +906,11 @@ def _inject_types_to_docstring(  # noqa: PLR0913, PLR0917
     what: str,
     name: str,
     lines: list[str],
+    has_overloads: bool = False,  # noqa: FBT001, FBT002
 ) -> None:
     if signature is not None:
         _inject_signature(type_hints, signature, app, lines)
-    if "return" in type_hints:
+    if "return" in type_hints and not has_overloads:
         _inject_rtype(type_hints, original_obj, app, what, name, lines)
 
 

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -810,7 +810,7 @@ def process_docstring(  # noqa: PLR0913, PLR0917
 def _inject_overload_signatures(  # noqa: C901
     app: Sphinx,
     what: str,
-    name: str,
+    name: str,  # noqa: ARG001
     obj: Any,
     lines: list[str],
 ) -> bool:

--- a/src/sphinx_autodoc_typehints/patches.py
+++ b/src/sphinx_autodoc_typehints/patches.py
@@ -116,30 +116,30 @@ def _patch_line_numbers() -> None:
     Body.doctest = _patched_body_doctest  # type: ignore[method-assign]
 
 
+_OVERLOADS_CACHE: dict[str, dict[Any, Any]] = {}
+
+
 @lru_cache
 def fix_directive_based_signature_formatting() -> None:
     """
-    Patch Sphinx 9's new directive-based autodoc to disable overload detection.
+    Patch Sphinx 9's new directive-based autodoc to cache and clear overload detection.
 
-    The new architecture adds overload signatures without emitting autodoc-process-signature
-    for each one. By patching ModuleAnalyzer to clear overloads after analysis, we prevent
-    overload detection while preserving other functionality like attribute discovery.
+    Overloads are cached before being cleared so we can render them in docstrings with
+    proper type formatting instead of in signatures where types can't be cross-referenced.
     """
     try:
         from sphinx.pycode import ModuleAnalyzer  # noqa: PLC0415
     except ImportError:
         return  # Not Sphinx 9+
 
-    # Store the original analyze method
     original_analyze = ModuleAnalyzer.analyze
 
     def patched_analyze(self: Any) -> None:
-        # Call the original analyze method
         original_analyze(self)
-        # Then clear the overloads to prevent overload signature generation
+        if self.overloads:
+            _OVERLOADS_CACHE[self.modname] = dict(self.overloads)
         self.overloads = {}
 
-    # Replace the analyze method
     ModuleAnalyzer.analyze = patched_analyze  # type: ignore[method-assign]
 
 
@@ -157,6 +157,7 @@ def install_patches(app: Sphinx) -> None:
     _patch_line_numbers()
 
 
-___all__ = [
+__all__ = [
+    "_OVERLOADS_CACHE",
     "install_patches",
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -661,6 +661,11 @@ def func_with_overload(a: str, b: str) -> None: ...
     """\
 mod.func_with_overload(a, b)
 
+   Overloads:
+      * **a** (int), **b** (int) → None
+
+      * **a** (str), **b** (str) → None
+
    f does the thing. The arguments can either be ints or strings but
    they must both have the same type.
 
@@ -668,9 +673,6 @@ mod.func_with_overload(a, b)
       * **a** ("int" | "str") -- The first thing
 
       * **b** ("int" | "str") -- The second thing
-
-   Return type:
-      "None"
 """,
 )
 def func_with_overload(a: Union[int, str], b: Union[int, str]) -> None:
@@ -685,6 +687,40 @@ def func_with_overload(a: Union[int, str], b: Union[int, str]) -> None:
     b:
         The second thing
     """
+
+
+@overload
+def overload_with_complex_types(x: list[int]) -> dict[str, int]: ...
+
+
+@overload
+def overload_with_complex_types(x: dict[str, int]) -> list[int]: ...
+
+
+@expected(
+    """\
+mod.overload_with_complex_types(x)
+
+   Overloads:
+      * **x** (list[int]) → dict[str, int]
+
+      * **x** (dict[str, int]) → list[int]
+
+   Function with overloaded complex types.
+
+   Parameters:
+      **x** ("list"["int"] | "dict"["str", "int"]) -- Input value
+""",
+)
+def overload_with_complex_types(x: list[int] | dict[str, int]) -> dict[str, int] | list[int]:
+    """Function with overloaded complex types.
+
+    Parameters:
+        x: Input value
+    """
+    if isinstance(x, list):
+        return {str(i): i for i in x}
+    return list(x.values())
 
 
 @expected(


### PR DESCRIPTION
PR #297 removed overload signature support to work around Sphinx not emitting `autodoc-process-signature` events for overloaded functions. This solved a technical issue but removed valuable type information from documentation. Users with complex overloaded APIs lost their distinct signature variants, making it harder to understand which types are valid for different use cases. 📚

The solution renders overloads in the docstring description instead of in signature lines. Overloads are cached during module analysis, then injected into docstrings as a formatted field list with proper RST cross-references. This avoids Sphinx's architectural limitation (signatures can't contain RST markup) while giving users complete type information. ✨

Functions decorated with `@overload` now show:

```
Overloads:
  * x (int) → str
  * x (list[int]) → dict[str, int]
```

All types are clickable cross-references in HTML output. Generic return types are automatically suppressed when overloads are present since each variant shows its specific return type.

Resolves #529