### PR TITLE
✨ feat(warnings): add source location context

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -29,6 +29,7 @@ from ._resolver import (
     _collect_documented_type_aliases,
     backfill_type_hints,
     get_all_type_hints,
+    get_obj_location,
     normalize_source_lines,
 )
 from .patches import _OVERLOADS_CACHE, install_patches
@@ -101,6 +102,7 @@ def process_signature(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0917
                     name,
                     type="sphinx_autodoc_typehints",
                     subtype="local_function",
+                    location=get_obj_location(obj),
                 )
                 return None
             outer = inspect.getmodule(obj)

--- a/src/sphinx_autodoc_typehints/_resolver.py
+++ b/src/sphinx_autodoc_typehints/_resolver.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+
 _TYPE_GUARD_IMPORT_RE = re.compile(
     r"""
     \n                          # leading newline before the guard
@@ -77,11 +78,13 @@ def _get_type_hint(
             result = {}
     except NameError as exc:
         _LOGGER.warning(
-            'Cannot resolve forward reference in type annotations of "%s": %s',
+            'Cannot resolve forward reference in type annotations of "%s" (module %s): %s',
             name,
+            getattr(obj, "__module__", "?"),
             exc,
             type="sphinx_autodoc_typehints",
             subtype="forward_reference",
+            location=get_obj_location(obj),
         )
         if sys.version_info >= (3, 14):
             result = annotationlib.get_annotations(obj, format=annotationlib.Format.FORWARDREF)
@@ -122,8 +125,14 @@ def _execute_guarded_code(autodoc_mock_imports: list[str], obj: Any, module_code
         try:
             _run_guarded_import(autodoc_mock_imports, obj, guarded_code)
         except Exception as exc:  # noqa: BLE001
+            module_name = getattr(obj, "__module__", None) or getattr(obj, "__name__", "?")
             _LOGGER.warning(
-                "Failed guarded type import with %r", exc, type="sphinx_autodoc_typehints", subtype="guarded_import"
+                "Failed guarded type import in %r: %r",
+                module_name,
+                exc,
+                type="sphinx_autodoc_typehints",
+                subtype="guarded_import",
+                location=get_obj_location(obj),
             )
 
 
@@ -180,6 +189,7 @@ def backfill_type_hints(obj: Any, name: str) -> dict[str, Any]:  # noqa: C901, P
                 len(children),
                 type="sphinx_autodoc_typehints",
                 subtype="multiple_ast_nodes",
+                location=get_obj_location(obj),
             )
             return None
         return children[0]
@@ -210,6 +220,7 @@ def backfill_type_hints(obj: Any, name: str) -> dict[str, Any]:  # noqa: C901, P
             name,
             type="sphinx_autodoc_typehints",
             subtype="comment",
+            location=get_obj_location(obj),
         )
         return {}
 
@@ -226,7 +237,11 @@ def backfill_type_hints(obj: Any, name: str) -> dict[str, Any]:  # noqa: C901, P
 
         if len(args) != len(comment_args):
             _LOGGER.warning(
-                'Not enough type comments found on "%s"', name, type="sphinx_autodoc_typehints", subtype="comment"
+                'Not enough type comments found on "%s"',
+                name,
+                type="sphinx_autodoc_typehints",
+                subtype="comment",
+                location=get_obj_location(obj),
             )
             return rv
 
@@ -236,6 +251,19 @@ def backfill_type_hints(obj: Any, name: str) -> dict[str, Any]:  # noqa: C901, P
             rv[arg.arg] = value
 
     return rv
+
+
+def get_obj_location(obj: Any) -> str | None:
+    try:
+        filepath = inspect.getsourcefile(obj) or inspect.getfile(obj)
+    except TypeError:
+        return None
+    try:
+        lineno = inspect.getsourcelines(obj)[1]
+    except (OSError, TypeError):
+        return filepath
+    else:
+        return f"{filepath}:{lineno}"
 
 
 def normalize_source_lines(source_lines: str) -> str:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ from sphinx.config import Config
 
 import sphinx_autodoc_typehints as sat
 from sphinx_autodoc_typehints import _inject_overload_signatures, process_docstring, process_signature
+from sphinx_autodoc_typehints._resolver import get_obj_location
 from sphinx_autodoc_typehints.patches import _OVERLOADS_CACHE
 
 
@@ -148,6 +149,23 @@ def test_inject_overload_empty_overloads_returns_false() -> None:
         assert _inject_overload_signatures(app, "function", "name", obj, []) is False
     finally:
         _OVERLOADS_CACHE.pop("test_mod2", None)
+
+
+def test_local_function_warning_includes_location() -> None:
+    def fake_method(self: Any, x: int) -> str: ...
+
+    fake_method.__annotations__ = {"x": int, "return": str}
+    fake_method.__qualname__ = "outer.<locals>.inner"
+    fake_method.__module__ = __name__
+
+    app = _make_sig_app()
+    mock_logger = MagicMock()
+    with patch("sphinx_autodoc_typehints._LOGGER", mock_logger):
+        process_signature(app, "method", "test.outer.<locals>.inner", fake_method, MagicMock(), "", "")
+    mock_logger.warning.assert_called_once()
+    kwargs = mock_logger.warning.call_args.kwargs
+    assert "location" in kwargs
+    assert kwargs["location"] == get_obj_location(fake_method)
 
 
 def test_inject_types_no_signature() -> None:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,7 +4,7 @@ import csv
 from csv import Error
 from textwrap import dedent
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from sphinx_autodoc_typehints import backfill_type_hints, normalize_source_lines
 from sphinx_autodoc_typehints._resolver import (
@@ -14,6 +14,7 @@ from sphinx_autodoc_typehints._resolver import (
     _resolve_type_guarded_imports,
     _run_guarded_import,
     _should_skip_guarded_import_resolution,
+    get_obj_location,
     split_type_comment_args,
 )
 
@@ -235,3 +236,70 @@ def _inline_typed_func(  # noqa: ANN202
 def _mismatched_type_comment(x, y, z):  # noqa: ANN202
     # type: (int) -> bool
     ...
+
+
+def test_get_obj_location_with_function() -> None:
+    location = get_obj_location(_typed_func)
+    assert location is not None
+    assert location.endswith(".py:" + str(_typed_func.__code__.co_firstlineno))
+    assert "test_resolver.py" in location
+
+
+def test_get_obj_location_with_class() -> None:
+    location = get_obj_location(_BackfillClass)
+    assert location is not None
+    assert "test_resolver.py" in location
+
+
+def test_get_obj_location_non_inspectable() -> None:
+    assert get_obj_location(42) is None
+
+
+def test_get_obj_location_no_source_lines() -> None:
+    with patch("sphinx_autodoc_typehints._resolver.inspect.getsourcelines", side_effect=OSError):
+        location = get_obj_location(_typed_func)
+    assert location is not None
+    assert location.endswith(".py")
+    assert ":" not in location.rsplit("/", 1)[-1]
+
+
+def test_forward_ref_warning_includes_module() -> None:
+    def func(x: int) -> str: ...
+
+    func.__module__ = "some_module"
+    func.__annotations__ = {"x": "NonExistent"}
+    mock_logger = MagicMock()
+    with (
+        patch("sphinx_autodoc_typehints._resolver.get_type_hints", side_effect=NameError("NonExistent")),
+        patch("sphinx_autodoc_typehints._resolver._LOGGER", mock_logger),
+    ):
+        _get_type_hint([], "func", func, {})
+    mock_logger.warning.assert_called_once()
+    args = mock_logger.warning.call_args
+    assert "some_module" in str(args)
+    assert "location" in args.kwargs
+
+
+def test_guarded_import_warning_includes_module() -> None:
+    module = type("FakeModule", (), {"__globals__": {}, "__dict__": {}, "__module__": "fake_mod"})()
+    mock_logger = MagicMock()
+    with (
+        patch("sphinx_autodoc_typehints._resolver._run_guarded_import", side_effect=RuntimeError("boom")),
+        patch("sphinx_autodoc_typehints._resolver._LOGGER", mock_logger),
+    ):
+        _execute_guarded_code([], module, "\nif TYPE_CHECKING:\n    import os\nx = 1\n")
+    mock_logger.warning.assert_called_once()
+    args = mock_logger.warning.call_args
+    assert "fake_mod" in str(args)
+
+
+def test_multi_child_ast_warning_includes_location() -> None:
+    mock_logger = MagicMock()
+    with (
+        patch("sphinx_autodoc_typehints._resolver.inspect.getsource", return_value="x = 1\ndef foo(): pass\n"),
+        patch("sphinx_autodoc_typehints._resolver._LOGGER", mock_logger),
+    ):
+        backfill_type_hints(lambda: None, "test")
+    mock_logger.warning.assert_called_once()
+    kwargs = mock_logger.warning.call_args.kwargs
+    assert "location" in kwargs


### PR DESCRIPTION
Warnings from sphinx-autodoc-typehints gave no indication which module or source file caused them. Messages like `"Failed guarded type import with ImportError(...)"` or `"Cannot resolve forward reference"` left users guessing, especially in large codebases with many documented modules. This addresses #238 and #403.

The fix adds a `_get_obj_location` helper that resolves `filepath:lineno` via `inspect`, and passes it to Sphinx's `location` kwarg on all six warning call sites. Sphinx's logging infrastructure formats this as a `filepath:lineno:` prefix in the output, matching the pattern already used by Napoleon and other extensions. The forward reference and guarded import warnings now also embed the originating module name directly in the message text for additional context.

Closes #238, closes #403