### PR TITLE
🧪 test(output): normalize Sphinx text for stable comparisons

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,24 @@ if TYPE_CHECKING:
 pytest_plugins = "sphinx.testing.fixtures"
 collect_ignore = ["roots"]
 
+_SPHINX_EMPHASIS_RE = re.compile(
+    r"""
+    (?<!\*\*)   # not preceded by ** (bold markup)
+    (?<!\*)     # not preceded by * (avoids partial match inside **)
+    \*          # opening *
+    ([^*\s]     # first char: not * or whitespace
+    [^*]*?)     # rest: non-greedy, no * chars
+    \*          # closing *
+    (?!\*)      # not followed by *
+    """,
+    re.VERBOSE,
+)
+
+
+def normalize_sphinx_text(text: str) -> str:
+    text = text.replace("\u2013", "--")
+    return _SPHINX_EMPHASIS_RE.sub(r'"\1"', text)
+
 
 @pytest.fixture(scope="session")
 def inv(pytestconfig: Config) -> Inventory:

--- a/tests/test_annotated_doc.py
+++ b/tests/test_annotated_doc.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import pytest
+from conftest import normalize_sphinx_text
 from typing_extensions import Doc
 
 from sphinx_autodoc_typehints import _extract_doc_description
@@ -50,7 +51,7 @@ def _load_and_build(
     monkeypatch.setitem(sys.modules, mod_name, module)
     app.build()
     assert "build succeeded" in status.getvalue()
-    return (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    return normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_generator_yields.py
+++ b/tests/test_generator_yields.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
+from conftest import normalize_sphinx_text
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Generator, Iterator
@@ -81,7 +82,7 @@ def _build_genclass(app: SphinxTestApp, monkeypatch: pytest.MonkeyPatch) -> str:
     )
     monkeypatch.setitem(sys.modules, "mod", sys.modules[__name__])
     app.build()
-    return (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    return normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
 
 
 @pytest.mark.sphinx("text", testroot="integration")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,7 @@ from typing import (  # no type comments
 )
 
 import pytest
+from conftest import normalize_sphinx_text
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
@@ -1594,9 +1595,9 @@ def test_integration(
     else:
         assert not value
 
-    result = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
 
-    expected = val.EXPECTED
+    expected = normalize_sphinx_text(val.EXPECTED)
     try:
         assert result.strip() == dedent(expected).strip()
     except Exception:

--- a/tests/test_integration_autodoc_type_aliases.py
+++ b/tests/test_integration_autodoc_type_aliases.py
@@ -7,6 +7,7 @@ from textwrap import dedent, indent
 from typing import TYPE_CHECKING, Any, Literal, NewType, TypeVar
 
 import pytest
+from conftest import normalize_sphinx_text
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -154,9 +155,9 @@ def test_integration(
     elif not re.search(r"WARNING: Inline strong start-string without end-string.", value):
         assert not value
 
-    result = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
 
-    expected = val.EXPECTED
+    expected = normalize_sphinx_text(val.EXPECTED)
     try:
         assert result.strip() == dedent(expected).strip()
     except Exception:

--- a/tests/test_integration_issue_347.py
+++ b/tests/test_integration_issue_347.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from conftest import normalize_sphinx_text
 
 numpydoc = pytest.importorskip("numpydoc")
 
@@ -95,7 +96,7 @@ def _build_and_get_output(
     monkeypatch.setitem(sys.modules, "mod_numpy", sys.modules[__name__])
     app.build()
     assert "build succeeded" in status.getvalue()
-    return (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    return normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
 
 
 @pytest.mark.sphinx("text", testroot="issue_347")

--- a/tests/test_integration_issue_384.py
+++ b/tests/test_integration_issue_384.py
@@ -7,6 +7,7 @@ from textwrap import dedent, indent
 from typing import TYPE_CHECKING, Any, NewType, TypeVar
 
 import pytest
+from conftest import normalize_sphinx_text
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -107,9 +108,9 @@ def test_integration(
     else:
         assert not value
 
-    result = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
 
-    expected = val.EXPECTED
+    expected = normalize_sphinx_text(val.EXPECTED)
     try:
         assert result.strip() == dedent(expected).strip()
     except Exception:

--- a/tests/test_integration_issue_572.py
+++ b/tests/test_integration_issue_572.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from conftest import normalize_sphinx_text
 
 from sphinx_autodoc_typehints._resolver import _get_type_hint
 
@@ -36,7 +37,7 @@ def test_forward_ref_builds_without_errors(
     (Path(app.srcdir) / "index.rst").write_text(template)
     app.build()
     assert "build succeeded" in status.getvalue()
-    result = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
     assert "Tree" in result
 
 

--- a/tests/test_integration_issue_599.py
+++ b/tests/test_integration_issue_599.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 from unittest.mock import MagicMock
 
 import pytest
+from conftest import normalize_sphinx_text
 from sphinx.util.inspect import TypeAliasForwardRef
 
 from sphinx_autodoc_typehints import format_annotation
@@ -127,9 +128,9 @@ def test_integration(
     value = warning.getvalue().strip()
     assert not value or "Inline strong start-string without end-string" in value
 
-    result = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
 
-    expected_text = val.EXPECTED
+    expected_text = normalize_sphinx_text(val.EXPECTED)
     try:
         assert result.strip() == dedent(expected_text).strip()
     except Exception:
@@ -159,7 +160,7 @@ def test_eager_annotations(
     value = warning.getvalue().strip()
     assert not value or "Inline strong start-string without end-string" in value
 
-    result = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
     assert '"UserId"' in result
 
 

--- a/tests/test_pyi_stubs.py
+++ b/tests/test_pyi_stubs.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from conftest import normalize_sphinx_text
 
 from sphinx_autodoc_typehints._resolver import (
     _STUB_AST_CACHE,
@@ -235,7 +236,7 @@ def test_sphinx_build_uses_stub_types(app: SphinxTestApp, status: StringIO, warn
     (Path(app.srcdir) / "index.rst").write_text(template)
     app.build()
     assert "build succeeded" in status.getvalue()
-    result = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
     assert "str" in result
     warn_text = warning.getvalue()
     assert "stub_mod" not in warn_text or "forward reference" not in warn_text

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -10,6 +10,7 @@ from unittest.mock import create_autospec, patch
 
 import pytest
 import typing_extensions
+from conftest import normalize_sphinx_text
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.ext.autodoc import Options
@@ -143,7 +144,7 @@ def test_always_document_param_types(
         else:
             format_args[key] = ""
 
-    contents = (Path(app.srcdir) / "_build/text/index.txt").read_text()
+    contents = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
     expected_contents = """\
     dummy_module.undocumented_function(x)
 
@@ -158,7 +159,7 @@ def test_always_document_param_types(
 
        __init__(x){undoc_params_1}
     """
-    expected_contents = dedent(expected_contents).format(**format_args)
+    expected_contents = normalize_sphinx_text(dedent(expected_contents).format(**format_args))
     assert contents == expected_contents
 
 
@@ -221,7 +222,7 @@ def test_sphinx_output_future_annotations(app: SphinxTestApp, status: StringIO) 
 
     assert "build succeeded" in status.getvalue()
 
-    contents = (Path(app.srcdir) / "_build/text/future_annotations.txt").read_text()
+    contents = normalize_sphinx_text((Path(app.srcdir) / "_build/text/future_annotations.txt").read_text())
     expected_contents = """\
     Dummy Module
     ************
@@ -240,8 +241,7 @@ def test_sphinx_output_future_annotations(app: SphinxTestApp, status: StringIO) 
        Return type:
           "str"
     """
-    expected_contents = dedent(expected_contents)
-    expected_contents = dedent(expected_contents)
+    expected_contents = normalize_sphinx_text(dedent(expected_contents))
     assert contents == expected_contents
 
 
@@ -308,7 +308,7 @@ def test_sphinx_output_defaults(
     app.build()
     assert "build succeeded" in status.getvalue()
 
-    contents = (Path(app.srcdir) / "_build/text/simple.txt").read_text()
+    contents = normalize_sphinx_text((Path(app.srcdir) / "_build/text/simple.txt").read_text())
     expected_contents = f"""\
     Simple Module
     *************
@@ -325,7 +325,7 @@ def test_sphinx_output_defaults(
        Return type:
           "str"
     """
-    assert contents == dedent(expected_contents)
+    assert contents == normalize_sphinx_text(dedent(expected_contents))
 
 
 @pytest.mark.parametrize(
@@ -355,7 +355,7 @@ def test_sphinx_output_formatter(
     app.build()
     assert "build succeeded" in status.getvalue()
 
-    contents = (Path(app.srcdir) / "_build/text/simple.txt").read_text()
+    contents = normalize_sphinx_text((Path(app.srcdir) / "_build/text/simple.txt").read_text())
     expected_contents = f"""\
     Simple Module
     *************
@@ -372,7 +372,7 @@ def test_sphinx_output_formatter(
        Return type:
           {expected[2]}
     """
-    assert contents == dedent(expected_contents)
+    assert contents == normalize_sphinx_text(dedent(expected_contents))
 
 
 @pytest.mark.parametrize("obj", [cmp_to_key, 1])
@@ -433,7 +433,7 @@ def test_sphinx_output_formatter_no_use_rtype(app: SphinxTestApp, status: String
     app.build()
     assert "build succeeded" in status.getvalue()
     text_path = Path(app.srcdir) / "_build" / "text" / "simple_no_use_rtype.txt"
-    text_contents = text_path.read_text().replace("–", "--")  # noqa: RUF001 # keep ambiguous EN DASH
+    text_contents = normalize_sphinx_text(text_path.read_text())
     expected_contents = """\
     Simple Module
     *************
@@ -486,7 +486,7 @@ def test_sphinx_output_formatter_no_use_rtype(app: SphinxTestApp, status: String
        Returns:
           "str" -- A string
     """
-    assert text_contents == dedent(expected_contents)
+    assert text_contents == normalize_sphinx_text(dedent(expected_contents))
 
 
 @pytest.mark.sphinx("text", testroot="dummy")
@@ -498,7 +498,7 @@ def test_sphinx_output_with_use_signature(app: SphinxTestApp, status: StringIO) 
     app.build()
     assert "build succeeded" in status.getvalue()
     text_path = Path(app.srcdir) / "_build" / "text" / "simple.txt"
-    text_contents = text_path.read_text().replace("–", "--")  # noqa: RUF001 # keep ambiguous EN DASH
+    text_contents = normalize_sphinx_text(text_path.read_text())
     expected_contents = """\
     Simple Module
     *************
@@ -515,7 +515,7 @@ def test_sphinx_output_with_use_signature(app: SphinxTestApp, status: StringIO) 
        Return type:
           "str"
     """
-    assert text_contents == dedent(expected_contents)
+    assert text_contents == normalize_sphinx_text(dedent(expected_contents))
 
 
 @pytest.mark.sphinx("text", testroot="dummy")
@@ -527,7 +527,7 @@ def test_sphinx_output_with_use_signature_return(app: SphinxTestApp, status: Str
     app.build()
     assert "build succeeded" in status.getvalue()
     text_path = Path(app.srcdir) / "_build" / "text" / "simple.txt"
-    text_contents = text_path.read_text().replace("–", "--")  # noqa: RUF001 # keep ambiguous EN DASH
+    text_contents = normalize_sphinx_text(text_path.read_text())
     expected_contents = """\
     Simple Module
     *************
@@ -544,7 +544,7 @@ def test_sphinx_output_with_use_signature_return(app: SphinxTestApp, status: Str
        Return type:
           "str"
     """
-    assert text_contents == dedent(expected_contents)
+    assert text_contents == normalize_sphinx_text(dedent(expected_contents))
 
 
 @pytest.mark.sphinx("text", testroot="dummy")
@@ -557,7 +557,7 @@ def test_sphinx_output_with_use_signature_and_return(app: SphinxTestApp, status:
     app.build()
     assert "build succeeded" in status.getvalue()
     text_path = Path(app.srcdir) / "_build" / "text" / "simple.txt"
-    text_contents = text_path.read_text().replace("–", "--")  # noqa: RUF001 # keep ambiguous EN DASH
+    text_contents = normalize_sphinx_text(text_path.read_text())
     expected_contents = """\
     Simple Module
     *************
@@ -574,7 +574,7 @@ def test_sphinx_output_with_use_signature_and_return(app: SphinxTestApp, status:
        Return type:
           "str"
     """
-    assert text_contents == dedent(expected_contents)
+    assert text_contents == normalize_sphinx_text(dedent(expected_contents))
 
 
 @pytest.mark.sphinx("text", testroot="dummy")
@@ -586,7 +586,7 @@ def test_default_annotation_without_typehints(app: SphinxTestApp, status: String
     app.build()
     assert "build succeeded" in status.getvalue()
     text_path = Path(app.srcdir) / "_build" / "text" / "without_complete_typehints.txt"
-    text_contents = text_path.read_text().replace("–", "--")  # noqa: RUF001 # keep ambiguous EN DASH
+    text_contents = normalize_sphinx_text(text_path.read_text())
     expected_contents = """\
     Simple Module
     *************
@@ -638,14 +638,14 @@ def test_default_annotation_without_typehints(app: SphinxTestApp, status: String
        Function docstring.
 
        Parameters:
-          * **x** (*int*) -- foo
+          * **x** ("int") -- foo
 
           * **y** (int, default: "0") -- bar
 
        Return type:
           "str"
     """
-    assert text_contents == dedent(expected_contents)
+    assert text_contents == normalize_sphinx_text(dedent(expected_contents))
 
 
 @pytest.mark.sphinx("text", testroot="dummy")


### PR DESCRIPTION
Sphinx's text builder can render the same cross-reference as either `"type"` or `*type*` depending on context — specifically whether PEP 604 union syntax (`X | Y`) appears in the source file. This made test assertions fragile and version-dependent, with 5 call sites doing ad-hoc EN DASH normalization and the rest doing nothing.

A `normalize_sphinx_text()` helper in `conftest.py` now canonicalizes both EN DASH characters and emphasis markup before comparison, applied consistently across all 18 text output comparison sites. Both the actual Sphinx output and expected strings are normalized, so tests pass regardless of which rendering form Sphinx chooses.

Closes #194