### PR TITLE
✨ feat(annotations): auto-remap internal type paths via intersphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ documentation -- so you write types once in code and they appear in your docs wi
   [dataclass](https://docs.python.org/3/library/dataclasses.html) classes
 - Shows default parameter values alongside types
 - Controls union display style (`Union[X, Y]` vs `X | Y`)
+- Automatically fixes cross-references for stdlib types whose runtime module differs from their documented path
 - Supports custom type formatters and module name rewriting
 - Extracts descriptions from [`Annotated[T, Doc(...)]`](https://typing-extensions.readthedocs.io/en/latest/#Doc)
   metadata
@@ -46,6 +47,7 @@ features above. See [Avoid duplicate types with built-in Sphinx](#avoid-duplicat
   - [Write a custom type formatter](#write-a-custom-type-formatter)
   - [Document a `NewType` or `type` alias without expanding it](#document-a-newtype-or-type-alias-without-expanding-it)
   - [Add types for C extensions or packages without annotations](#add-types-for-c-extensions-or-packages-without-annotations)
+  - [Fix cross-reference links for stdlib types](#fix-cross-reference-links-for-stdlib-types)
   - [Fix cross-reference links for renamed modules](#fix-cross-reference-links-for-renamed-modules)
   - [Suppress warnings](#suppress-warnings)
 - [Reference](#reference)
@@ -265,10 +267,37 @@ The extension reads [`.pyi` stub files](https://typing.python.org/en/latest/spec
 automatically. Place a `.pyi` file next to the `.so`/`.pyd` file (or as `__init__.pyi` in the package directory) with
 the type annotations, and they'll be picked up.
 
+### Fix cross-reference links for stdlib types
+
+Many Python stdlib classes have a `__module__` that points to an internal module rather than their public documented
+path. For example, `threading.local` reports its module as `_thread._local`, and `concurrent.futures.Executor` as
+`concurrent.futures._base.Executor`. This produces broken cross-reference links because the extension builds links from
+`__module__.__qualname__`.
+
+When [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) is enabled, the extension
+automatically fixes this. After intersphinx loads its inventories, it builds a reverse mapping from runtime paths to
+documented paths and applies it during annotation formatting. No configuration is needed — just make sure intersphinx is
+loaded:
+
+```python
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+```
+
+With this, a type hint like `threading.local` correctly links to `threading.local` in the Python docs instead of
+producing a broken `_thread._local` reference.
+
 ### Fix cross-reference links for renamed modules
 
-Some libraries expose types under a different module path than where they're documented. For example, GTK types live at
-`gi.repository.Gtk.Window` in Python, but their docs list them as `Gtk.Window`. This causes broken
+Some third-party libraries expose types under a different module path than where they're documented. For example, GTK
+types live at `gi.repository.Gtk.Window` in Python, but their docs list them as `Gtk.Window`. This causes broken
 [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) links.
 
 Use `typehints_fixup_module_name` to rewrite the module path before links are generated:

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -24,6 +24,7 @@ from ._annotations import (
 from ._formats import detect_format
 from ._formats._numpydoc import _convert_numpydoc_to_sphinx_fields  # noqa: F401
 from ._formats._sphinx import _has_yields_section, _is_generator_type
+from ._intersphinx import build_type_mapping
 from ._parser import parse
 from ._resolver import (
     backfill_attrs_annotations,
@@ -381,6 +382,8 @@ def validate_config(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> 
     if formatter is not None and not callable(formatter):
         msg = f"typehints_formatter needs to be callable or `None`, not {formatter}"
         raise ValueError(msg)
+
+    app.config._intersphinx_type_mapping = build_type_mapping(env)  # noqa: SLF001
 
 
 def sphinx_autodoc_typehints_type_role(

--- a/src/sphinx_autodoc_typehints/_annotations.py
+++ b/src/sphinx_autodoc_typehints/_annotations.py
@@ -106,6 +106,9 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
         return str(annotation).strip("'")
 
     module = _fixup_module_name(config, module)
+    internal_path = f"{module}.{class_name}"
+    if (mapping := getattr(config, "_intersphinx_type_mapping", None)) and (mapped := mapping.get(internal_path)):
+        module, _, class_name = mapped.rpartition(".")
     full_name = f"{module}.{class_name}" if module != "builtins" else class_name
     fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
     prefix = "" if fully_qualified or full_name == class_name else "~"

--- a/src/sphinx_autodoc_typehints/_intersphinx.py
+++ b/src/sphinx_autodoc_typehints/_intersphinx.py
@@ -1,0 +1,40 @@
+"""Build a reverse mapping from runtime type paths to intersphinx-documented paths."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sphinx.environment import BuildEnvironment
+
+_ROLES = frozenset({"py:class", "py:function", "py:exception", "py:data"})
+
+
+def build_type_mapping(env: BuildEnvironment) -> dict[str, str]:
+    """Map internal ``__module__.__qualname__`` paths to their documented intersphinx names."""
+    if not hasattr(env, "intersphinx_inventory"):
+        return {}
+
+    inventory_data: dict[str, dict[str, object]] = env.intersphinx_inventory.data  # ty: ignore[unresolved-attribute]
+    all_documented: set[str] = set()
+    candidates: list[tuple[str, str]] = []
+
+    for role in _ROLES:
+        if (entries := inventory_data.get(role)) is None:
+            continue
+        for documented_name in entries:
+            all_documented.add(documented_name)
+            mod_path, _, attr_name = documented_name.rpartition(".")
+            if not mod_path:
+                continue
+            try:
+                mod = importlib.import_module(mod_path)
+                obj = getattr(mod, attr_name)
+            except Exception:  # noqa: BLE001, S112
+                continue
+            internal_path = f"{obj.__module__}.{obj.__qualname__}"
+            if internal_path != documented_name:
+                candidates.append((internal_path, documented_name))
+
+    return {internal: documented for internal, documented in candidates if internal not in all_documented}

--- a/tests/test_intersphinx_mapping.py
+++ b/tests/test_intersphinx_mapping.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock, create_autospec
+
+from sphinx.config import Config
+
+from sphinx_autodoc_typehints import format_annotation
+from sphinx_autodoc_typehints._intersphinx import build_type_mapping
+
+
+def _make_env(inventory_data: dict[str, dict[str, object]] | None = None) -> MagicMock:
+    env = MagicMock()
+    if inventory_data is None:
+        del env.intersphinx_inventory
+    else:
+        env.intersphinx_inventory.data = inventory_data
+    return env
+
+
+def test_build_type_mapping_threading_local() -> None:
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:class": {"threading.local": ("", "", "", "")},
+    }
+    result = build_type_mapping(_make_env(inventory_data))
+    assert result["_thread._local"] == "threading.local"
+
+
+def test_build_type_mapping_no_intersphinx_inventory() -> None:
+    assert build_type_mapping(_make_env()) == {}
+
+
+def test_build_type_mapping_skips_already_documented() -> None:
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:class": {
+            "threading.local": ("", "", "", ""),
+            "_thread._local": ("", "", "", ""),
+        },
+    }
+    result = build_type_mapping(_make_env(inventory_data))
+    assert "_thread._local" not in result
+
+
+def test_build_type_mapping_skips_unimportable() -> None:
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:class": {"nonexistent_module.SomeClass": ("", "", "", "")},
+    }
+    assert build_type_mapping(_make_env(inventory_data)) == {}
+
+
+def test_build_type_mapping_skips_missing_attr() -> None:
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:class": {"threading.NoSuchAttribute": ("", "", "", "")},
+    }
+    assert build_type_mapping(_make_env(inventory_data)) == {}
+
+
+def test_build_type_mapping_skips_same_path() -> None:
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:class": {"int": ("", "", "", "")},
+    }
+    result = build_type_mapping(_make_env(inventory_data))
+    assert "builtins.int" not in result
+
+
+def test_build_type_mapping_multiple_roles() -> None:
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:class": {"threading.local": ("", "", "", "")},
+        "py:function": {},
+        "py:exception": {},
+    }
+    result = build_type_mapping(_make_env(inventory_data))
+    assert result["_thread._local"] == "threading.local"
+
+
+def test_format_annotation_applies_intersphinx_mapping() -> None:
+    conf = create_autospec(
+        Config,
+        _intersphinx_type_mapping={"_thread._local": "threading.local"},
+        always_use_bars_union=False,
+    )
+    result = format_annotation(threading.local, conf)
+    assert result == ":py:class:`~threading.local`"
+
+
+def test_format_annotation_without_mapping() -> None:
+    conf = create_autospec(Config, always_use_bars_union=False)
+    result = format_annotation(threading.local, conf)
+    assert result == ":py:class:`~_thread._local`"


### PR DESCRIPTION
Many stdlib classes expose a `__module__` that points to an internal/private module rather than their documented public path — for example `threading.local` reports as `_thread._local`, and `concurrent.futures.Executor` as `concurrent.futures._base.Executor`. This causes sphinx-autodoc-typehints to generate broken cross-references, since it builds links from `__module__.__qualname__`. Users have been working around this by monkey-patching `PythonDomain.resolve_xref` with hardcoded correction tables.

This PR eliminates the need for manual mappings by automatically building a reverse lookup at Sphinx build time. After intersphinx loads its inventories (on `builder-inited`), the new `build_type_mapping` function iterates documented names across `py:class`, `py:function`, `py:exception`, and `py:data` roles, imports each one, and compares its runtime `__module__.__qualname__` against the documented path. Mismatches are recorded and applied during `format_annotation`, so cross-references like `threading.local` are emitted instead of broken `_thread._local` links. Entries where the internal path is already separately documented in the inventory are filtered out to avoid incorrect remaps (e.g. `builtins.OSError` to `dbm.dumb.error`).

Import and attribute errors are silently suppressed since inventories may reference platform-specific or unavailable modules. The mapping is stored on `app.config._intersphinx_type_mapping` and looked up via `getattr` with a fallback, so builds without intersphinx remain completely unaffected.