### PR TITLE
🐛 fix(intersphinx): access inventory dict directly

### DIFF
--- a/src/sphinx_autodoc_typehints/_intersphinx.py
+++ b/src/sphinx_autodoc_typehints/_intersphinx.py
@@ -16,7 +16,7 @@ def build_type_mapping(env: BuildEnvironment) -> dict[str, str]:
     if not hasattr(env, "intersphinx_inventory"):
         return {}
 
-    inventory_data: dict[str, dict[str, object]] = env.intersphinx_inventory.data  # ty: ignore[unresolved-attribute]
+    inventory_data: dict[str, dict[str, object]] = env.intersphinx_inventory  # ty: ignore[invalid-assignment]
     all_documented: set[str] = set()
     candidates: list[tuple[str, str]] = []
 

--- a/tests/test_intersphinx_mapping.py
+++ b/tests/test_intersphinx_mapping.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
 import threading
-from typing import Any
-from unittest.mock import MagicMock, create_autospec
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import create_autospec
 
 from sphinx.config import Config
 
 from sphinx_autodoc_typehints import format_annotation
 from sphinx_autodoc_typehints._intersphinx import build_type_mapping
 
+if TYPE_CHECKING:
+    from sphinx.environment import BuildEnvironment
 
-def _make_env(inventory_data: dict[str, dict[str, object]] | None = None) -> MagicMock:
-    env = MagicMock()
+
+def _make_env(inventory_data: dict[str, dict[str, object]] | None = None) -> BuildEnvironment:
     if inventory_data is None:
-        del env.intersphinx_inventory
-    else:
-        env.intersphinx_inventory.data = inventory_data
-    return env
+        return cast("BuildEnvironment", SimpleNamespace())
+    return cast("BuildEnvironment", SimpleNamespace(intersphinx_inventory=inventory_data))
 
 
 def test_build_type_mapping_threading_local() -> None:


### PR DESCRIPTION
Sphinx 9.1 sets `env.intersphinx_inventory` as a plain `dict` via `InventoryAdapter.__init__`, but `build_type_mapping` was accessing `.data` on it — an attribute that doesn't exist on a dict. This caused `AttributeError: 'dict' object has no attribute 'data'` during any Sphinx build using intersphinx with this extension. 🐛

The fix removes the spurious `.data` access and reads the inventory dict directly. The tests previously used `MagicMock` for the environment, which silently auto-created the `.data` attribute chain and masked the mismatch. Switching to `SimpleNamespace` ensures the mock faithfully mirrors Sphinx's runtime structure — any future attribute access mistakes will raise immediately rather than hiding behind mock magic.