### PR TITLE
🐛 fix(intersphinx): handle objects without __qualname__

### DIFF
--- a/src/sphinx_autodoc_typehints/_intersphinx.py
+++ b/src/sphinx_autodoc_typehints/_intersphinx.py
@@ -31,9 +31,9 @@ def build_type_mapping(env: BuildEnvironment) -> dict[str, str]:
             try:
                 mod = importlib.import_module(mod_path)
                 obj = getattr(mod, attr_name)
+                internal_path = f"{obj.__module__}.{obj.__qualname__}"
             except Exception:  # noqa: BLE001, S112
                 continue
-            internal_path = f"{obj.__module__}.{obj.__qualname__}"
             if internal_path != documented_name:
                 candidates.append((internal_path, documented_name))
 

--- a/tests/test_intersphinx_mapping.py
+++ b/tests/test_intersphinx_mapping.py
@@ -11,6 +11,7 @@ from sphinx_autodoc_typehints import format_annotation
 from sphinx_autodoc_typehints._intersphinx import build_type_mapping
 
 if TYPE_CHECKING:
+    import pytest
     from sphinx.environment import BuildEnvironment
 
 
@@ -53,6 +54,15 @@ def test_build_type_mapping_skips_unimportable() -> None:
 def test_build_type_mapping_skips_missing_attr() -> None:
     inventory_data: dict[str, dict[str, Any]] = {
         "py:class": {"threading.NoSuchAttribute": ("", "", "", "")},
+    }
+    assert build_type_mapping(_make_env(inventory_data)) == {}
+
+
+def test_build_type_mapping_skips_no_qualname(monkeypatch: pytest.MonkeyPatch) -> None:
+    obj_no_qualname = SimpleNamespace(__module__="os")
+    monkeypatch.setattr("os.getcwd", obj_no_qualname)
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:function": {"os.getcwd": ("", "", "", "")},
     }
     assert build_type_mapping(_make_env(inventory_data)) == {}
 


### PR DESCRIPTION
C extension types like `CFunctionType` lack `__qualname__`, which caused an `AttributeError` in `build_type_mapping` when intersphinx inventory entries resolved to such objects. 🐛 This broke Sphinx doc builds for projects whose intersphinx inventories reference C-level functions or types (e.g. filelock with `ctypes` entries).

The `__module__` and `__qualname__` attribute access was sitting outside the existing `try/except` block that already handles import and attribute lookup failures. Moving it inside means these entries are silently skipped, consistent with how unimportable or missing attributes are already handled.