### PR TITLE
🐛 fix(intersphinx): exclude builtin type aliases from mapping

### DIFF
--- a/src/sphinx_autodoc_typehints/_intersphinx.py
+++ b/src/sphinx_autodoc_typehints/_intersphinx.py
@@ -27,6 +27,7 @@ def build_type_mapping(env: BuildEnvironment) -> dict[str, str]:
             all_documented.add(documented_name)
             mod_path, _, attr_name = documented_name.rpartition(".")
             if not mod_path:
+                all_documented.add(f"builtins.{documented_name}")
                 continue
             try:
                 mod = importlib.import_module(mod_path)

--- a/tests/test_intersphinx_mapping.py
+++ b/tests/test_intersphinx_mapping.py
@@ -85,6 +85,17 @@ def test_build_type_mapping_multiple_roles() -> None:
     assert result["_thread._local"] == "threading.local"
 
 
+def test_build_type_mapping_skips_builtin_alias() -> None:
+    inventory_data: dict[str, dict[str, Any]] = {
+        "py:class": {
+            "dict": ("", "", "", ""),
+            "wsgiref.types.WSGIEnvironment": ("", "", "", ""),
+        },
+    }
+    result = build_type_mapping(_make_env(inventory_data))
+    assert "builtins.dict" not in result
+
+
 def test_format_annotation_applies_intersphinx_mapping() -> None:
     conf = create_autospec(
         Config,


### PR DESCRIPTION
When `docs.python.org` is configured as an intersphinx mapping, `dict` types get incorrectly resolved as `wsgiref.types.WSGIEnvironment`. This happens because `WSGIEnvironment` is a type alias for `dict[str, Any]`, and at runtime its `__module__.__qualname__` resolves to `builtins.dict` — which the mapping then records as a remapping target.

The root cause is that bare inventory names like `dict`, `int`, `str` have no module prefix, so `rpartition(".")` yields an empty module path and skips resolution entirely. This meant `builtins.dict` never entered the exclusion set, allowing type aliases that resolve to builtins to incorrectly claim the mapping.

The fix adds `builtins.{name}` to the exclusion set for all bare inventory names, ensuring type aliases pointing to builtins are filtered out.

Fixes #649