### PR TITLE
🐛 fix(stubs): resolve relative imports in .pyi stubs

### DIFF
--- a/src/sphinx_autodoc_typehints/_resolver/_stubs.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_stubs.py
@@ -37,34 +37,57 @@ def _get_stub_context(obj: Any) -> tuple[dict[str, Any], set[str], str]:
     stub_path, owner_module = info
     if (tree := _parse_stub_ast(stub_path)) is None:
         return {}, set(), ""
+    owner_package = getattr(owner_module, "__package__", None) or owner_module.__name__
     ns: dict[str, Any] = dict(vars(owner_module))
-    ns.update(_resolve_stub_imports(tree))
+    ns.update(_resolve_stub_imports(tree, owner_package))
     return ns, _extract_type_alias_names(tree), owner_module.__name__
 
 
-def _resolve_stub_imports(tree: ast.Module) -> dict[str, Any]:
+def _resolve_stub_imports(tree: ast.Module, owner_package: str = "") -> dict[str, Any]:
     ns: dict[str, Any] = {}
     for node in tree.body:
         if isinstance(node, ast.Import):
-            for alias in node.names:
-                with contextlib.suppress(ImportError):
-                    if alias.asname:
-                        ns[alias.asname] = importlib.import_module(alias.name)
-                    else:
-                        top = alias.name.split(".")[0]
-                        ns[top] = importlib.import_module(top)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            try:
-                mod = importlib.import_module(node.module)
-            except ImportError:
-                continue
-            for alias in node.names:
-                if alias.name == "*":
-                    continue
-                name = alias.asname or alias.name
-                if (val := getattr(mod, alias.name, None)) is not None:
-                    ns[name] = val
+            _resolve_import_node(node, ns)
+        elif isinstance(node, ast.ImportFrom):
+            _resolve_import_from_node(node, owner_package, ns)
     return ns
+
+
+def _resolve_import_node(node: ast.Import, ns: dict[str, Any]) -> None:
+    for alias in node.names:
+        with contextlib.suppress(ImportError):
+            if alias.asname:
+                ns[alias.asname] = importlib.import_module(alias.name)
+            else:
+                top = alias.name.split(".")[0]
+                ns[top] = importlib.import_module(top)
+
+
+def _resolve_import_from_node(node: ast.ImportFrom, owner_package: str, ns: dict[str, Any]) -> None:
+    if (module_name := _resolve_import_from(node, owner_package)) is None:
+        return
+    try:
+        mod = importlib.import_module(module_name)
+    except ImportError:
+        return
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        name = alias.asname or alias.name
+        if (val := getattr(mod, alias.name, None)) is not None:
+            ns[name] = val
+
+
+def _resolve_import_from(node: ast.ImportFrom, owner_package: str) -> str | None:
+    if not node.level:
+        return node.module or None
+    if not owner_package:
+        return node.module or None
+    parts = owner_package.rsplit(".", node.level - 1)
+    if len(parts) < node.level:
+        return None
+    base = parts[0]
+    return f"{base}.{node.module}" if node.module else base
 
 
 def _get_module(obj: Any) -> types.ModuleType | None:

--- a/tests/test_resolver/test_stubs.py
+++ b/tests/test_resolver/test_stubs.py
@@ -26,6 +26,7 @@ from sphinx_autodoc_typehints._resolver._stubs import (
     _get_module,
     _get_stub_context,
     _parse_stub_ast,
+    _resolve_import_from,
     _resolve_stub_imports,
 )
 
@@ -561,3 +562,60 @@ def test_get_stub_context_includes_owner_module_vars(tmp_path: Path) -> None:
     assert ns["Sequence"] is Sequence
     assert ns["MyAlias"] is int
     assert owner == "mypkg"
+
+
+@pytest.mark.parametrize(
+    ("source", "owner_package", "expected"),
+    [
+        pytest.param("from typing import Any", "", "typing", id="absolute"),
+        pytest.param("from .typing import ColorType", "matplotlib", "matplotlib.typing", id="rel_level1"),
+        pytest.param("from . import utils", "matplotlib", "matplotlib", id="rel_level1_bare"),
+        pytest.param("from ..typing import X", "matplotlib.figure", "matplotlib.typing", id="rel_level2"),
+        pytest.param("from .sub import Y", "", "sub", id="rel_no_package"),
+    ],
+)
+def test_resolve_import_from(source: str, owner_package: str, expected: str) -> None:
+    tree = ast.parse(source)
+    node = tree.body[0]
+    assert isinstance(node, ast.ImportFrom)
+    assert _resolve_import_from(node, owner_package) == expected
+
+
+def test_resolve_import_from_level_beyond_package() -> None:
+    node = ast.parse("from ...x import Y").body[0]
+    assert isinstance(node, ast.ImportFrom)
+    assert _resolve_import_from(node, "a") is None
+
+
+def test_resolve_stub_imports_relative() -> None:
+    source = "from .typing import ColorType\nfrom typing import Any\n"
+    tree = ast.parse(source)
+    # matplotlib.typing.ColorType is a type alias, check it resolves to something
+    ns = _resolve_stub_imports(tree, "matplotlib")
+    assert "Any" in ns
+    assert ns["Any"] is Any
+
+
+def test_get_stub_context_resolves_relative_imports(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "relpkg"
+    pkg_dir.mkdir()
+    sub_dir = pkg_dir / "sub"
+    sub_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (sub_dir / "__init__.py").write_text("")
+    (sub_dir / "mod.py").write_text("class Cls:\n    pass\n")
+    (sub_dir / "mod.pyi").write_text("from typing import Any\nfrom ..helpers import Helper\nclass Cls:\n    x: Any\n")
+    (pkg_dir / "helpers.py").write_text("class Helper:\n    pass\n")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        import relpkg.sub.mod  # noqa: PLC0415  # ty: ignore[unresolved-import]
+
+        ns, _names, owner = _get_stub_context(relpkg.sub.mod.Cls)
+        assert owner == "relpkg.sub.mod"
+        assert "Helper" in ns
+    finally:
+        sys.path.pop(0)
+        for mod_name in [k for k in sys.modules if k.startswith("relpkg")]:
+            sys.modules.pop(mod_name, None)
+        _STUB_AST_CACHE.clear()


### PR DESCRIPTION
Libraries like matplotlib ship `.pyi` stub files that use relative imports (e.g. `from .typing import ColorType` in `figure.pyi`). When a user's class inherits from a stubbed parent like `matplotlib.figure.Figure`, the stub import resolver needs to evaluate these imports to build the namespace for type hint resolution. The resolver was treating all `ImportFrom` nodes as absolute, so `from .typing import ColorType` resolved to stdlib `typing` instead of `matplotlib.typing`. 🔍 This left `ColorType` unresolvable, producing spurious "Cannot resolve forward reference" warnings on every inherited method.

The fix passes the owner module's `__package__` into the stub import resolver and converts relative import paths to absolute module names using Python's own resolution logic. `from .typing import ColorType` in a stub owned by `matplotlib.figure` now correctly resolves to `matplotlib.typing.ColorType`. ✅

This affects any project that inherits from or documents classes whose type annotations live in `.pyi` stubs with relative imports. No configuration changes needed.

Fixes #662