### PR TITLE
🐛 fix(stubs): resolve imports inside if-blocks in .pyi stubs

### DIFF
--- a/src/sphinx_autodoc_typehints/_resolver/_stubs.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_stubs.py
@@ -45,12 +45,19 @@ def _get_stub_context(obj: Any) -> tuple[dict[str, Any], set[str], str]:
 
 def _resolve_stub_imports(tree: ast.Module, owner_package: str = "") -> dict[str, Any]:
     ns: dict[str, Any] = {}
-    for node in tree.body:
+    _resolve_stub_imports_from_body(tree.body, owner_package, ns)
+    return ns
+
+
+def _resolve_stub_imports_from_body(body: list[ast.stmt], owner_package: str, ns: dict[str, Any]) -> None:
+    for node in body:
         if isinstance(node, ast.Import):
             _resolve_import_node(node, ns)
         elif isinstance(node, ast.ImportFrom):
             _resolve_import_from_node(node, owner_package, ns)
-    return ns
+        elif isinstance(node, ast.If):
+            _resolve_stub_imports_from_body(node.body, owner_package, ns)
+            _resolve_stub_imports_from_body(node.orelse, owner_package, ns)
 
 
 def _resolve_import_node(node: ast.Import, ns: dict[str, Any]) -> None:

--- a/tests/test_resolver/test_stubs.py
+++ b/tests/test_resolver/test_stubs.py
@@ -601,6 +601,20 @@ def test_resolve_import_from_level_beyond_package() -> None:
     assert _resolve_import_from(node, "a") is None
 
 
+def test_resolve_stub_imports_handles_conditional_blocks() -> None:
+    source = (
+        "import os\n"
+        "if sys.version_info >= (3, 11):\n"
+        "    from typing import Self\n"
+        "else:\n"
+        "    from typing_extensions import Self\n"
+    )
+    tree = ast.parse(source)
+    ns = _resolve_stub_imports(tree, "")
+    assert "os" in ns
+    assert "Self" in ns
+
+
 def test_resolve_stub_imports_relative() -> None:
     source = "from .typing import ColorType\nfrom typing import Any\n"
     tree = ast.parse(source)


### PR DESCRIPTION
Stub files commonly guard imports behind version checks like `if sys.version_info >= (3, 11): from typing import Self`. The stub import resolver only processed top-level import statements, so guarded names like `Self` were missing from the namespace and caused `NameError` warnings when evaluating `__new__` return annotations.

This extends `_resolve_stub_imports` to recurse into `if`/`else` bodies. In `.pyi` stubs, all branches represent valid type information regardless of the runtime guard, so resolving imports from both branches is correct.

Validated against [cbor2 rust branch](https://github.com/agronholm/cbor2/pull/278) (4 `Self` warnings eliminated) and the [matplotlib reproduction case from #664](https://github.com/tox-dev/sphinx-autodoc-typehints/issues/664) (forward reference warnings eliminated).

Closes #666