### PR TITLE
🐛 fix(stubs): evaluate stub-only definitions for annotation resolution

### DIFF
--- a/src/sphinx_autodoc_typehints/_resolver/_stubs.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_stubs.py
@@ -7,6 +7,7 @@ import contextlib
 import importlib
 import inspect
 import sys
+from copy import copy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -46,6 +47,7 @@ def _get_stub_context(obj: Any) -> tuple[dict[str, Any], set[str], str]:
 def _resolve_stub_imports(tree: ast.Module, owner_package: str = "") -> dict[str, Any]:
     ns: dict[str, Any] = {}
     _resolve_stub_imports_from_body(tree.body, owner_package, ns)
+    _resolve_stub_definitions(tree.body, ns)
     return ns
 
 
@@ -58,6 +60,28 @@ def _resolve_stub_imports_from_body(body: list[ast.stmt], owner_package: str, ns
         elif isinstance(node, ast.If):
             _resolve_stub_imports_from_body(node.body, owner_package, ns)
             _resolve_stub_imports_from_body(node.orelse, owner_package, ns)
+
+
+_STUB_DEFINITION_TYPES = (ast.Assign, ast.AnnAssign, ast.ClassDef, ast.TypeAlias)
+
+
+def _resolve_stub_definitions(body: list[ast.stmt], ns: dict[str, Any]) -> None:
+    for node in body:
+        if isinstance(node, _STUB_DEFINITION_TYPES):
+            exec_node = _strip_class_decorators(node) if isinstance(node, ast.ClassDef) else node
+            with contextlib.suppress(Exception):
+                exec(compile(ast.Module(body=[exec_node], type_ignores=[]), "<stub>", "exec"), ns)  # noqa: S102
+        elif isinstance(node, ast.If):
+            _resolve_stub_definitions(node.body, ns)
+            _resolve_stub_definitions(node.orelse, ns)
+
+
+def _strip_class_decorators(node: ast.ClassDef) -> ast.ClassDef:
+    if not node.decorator_list:
+        return node
+    stripped = copy(node)
+    stripped.decorator_list = []
+    return stripped
 
 
 def _resolve_import_node(node: ast.Import, ns: dict[str, Any]) -> None:

--- a/tests/test_resolver/test_stubs.py
+++ b/tests/test_resolver/test_stubs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import os
 import sys
+import textwrap
 import types
 from collections.abc import Sequence
 from pathlib import Path
@@ -602,17 +603,30 @@ def test_resolve_import_from_level_beyond_package() -> None:
 
 
 def test_resolve_stub_imports_handles_conditional_blocks() -> None:
-    source = (
-        "import os\n"
-        "if sys.version_info >= (3, 11):\n"
-        "    from typing import Self\n"
-        "else:\n"
-        "    from typing_extensions import Self\n"
-    )
+    source = textwrap.dedent("""\
+        import os
+        if sys.version_info >= (3, 11):
+            from typing import Self
+        else:
+            from typing_extensions import Self
+    """)
     tree = ast.parse(source)
     ns = _resolve_stub_imports(tree, "")
     assert "os" in ns
     assert "Self" in ns
+
+
+def test_resolve_stub_definitions_evaluates_typevars_and_classes() -> None:
+    source = textwrap.dedent("""\
+        from typing import TypeVar, TypedDict
+        _T = TypeVar("_T")
+        class MyDict(TypedDict):
+            x: int
+    """)
+    tree = ast.parse(source)
+    ns = _resolve_stub_imports(tree, "")
+    assert "_T" in ns
+    assert "MyDict" in ns
 
 
 def test_resolve_stub_imports_relative() -> None:


### PR DESCRIPTION
Stub files define names that don't exist at runtime: `TypeVar` definitions like `_ScalarT = TypeVar("_ScalarT", bound=generic)` and `TypedDict` classes decorated with `@type_check_only`. These stub-only names were missing from the evaluation namespace, causing `NameError` warnings when `get_type_hints` tried to resolve annotations referencing them.

This extends `_resolve_stub_imports` to also evaluate top-level definitions (assignments, classes, type aliases) from stubs after imports are resolved. Class decorators like `@type_check_only` are stripped before execution since they may not exist at runtime.

Validated against the numpy reproduction from #669 (`_ScalarT`/`_UFuncKwargs` warnings eliminated) and confirmed no regressions against cbor2 and matplotlib test cases.

Closes #669