### PR TITLE
✨ feat(resolver): auto-inject :vartype: for annotated instance vars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ lint.ignore = [
   "S104",   # Possible binding to all interface
 ]
 lint.per-file-ignores."tests/**/*.py" = [
+  "B903",    # test fixture classes intentionally use plain __init__ without dataclass
   "D",       # don't care about documentation in tests
   "FBT",     # don't care about booleans as positional arguments in tests
   "INP001",  # no implicit namespace

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -31,6 +31,7 @@ from ._resolver import (
     backfill_type_hints,
     collect_documented_type_aliases,
     get_all_type_hints,
+    get_instance_var_annotations,
     get_obj_location,
 )
 from .patches import _OVERLOADS_CACHE, install_patches
@@ -151,6 +152,9 @@ def process_docstring(  # noqa: PLR0913, PLR0917
         return
     if inspect.isclass(obj):
         backfill_attrs_annotations(obj)
+        ivar_annotations = get_instance_var_annotations(obj)
+    else:
+        ivar_annotations = {}
     use_class_for_signature = False
     cls_for_hints = None
     if inspect.isclass(obj):
@@ -188,6 +192,7 @@ def process_docstring(  # noqa: PLR0913, PLR0917
     try:
         has_overloads = _inject_overload_signatures(app, what, name, obj, lines)
         _inject_types_to_docstring(type_hints, signature, original_obj, app, what, name, lines, has_overloads)
+        _inject_ivar_types(ivar_annotations, app, lines)
     finally:
         del app.config._annotation_globals  # noqa: SLF001
         del app.config._typehints_env  # noqa: SLF001
@@ -406,6 +411,30 @@ def _inject_rtype(  # noqa: PLR0913, PLR0917
     )
 
     fmt.inject_rtype(lines, formatted_annotation, r, use_rtype=app.config.typehints_use_rtype)
+
+
+def _inject_ivar_types(ivar_annotations: dict[str, Any], app: Sphinx, lines: list[str]) -> None:
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.startswith(":ivar "):
+            i += 1
+            continue
+        _ivar, *type_tokens, attr_name = line.split(":", maxsplit=2)[1].split()
+        has_inline_type = bool(type_tokens)
+        has_vartype = any(ln.startswith(f":vartype {attr_name}:") for ln in lines)
+        if not has_inline_type and not has_vartype and attr_name in ivar_annotations:
+            formatted = add_type_css_class(
+                format_annotation(
+                    ivar_annotations[attr_name],
+                    app.config,
+                    short_literals=app.config.python_display_short_literal_types,
+                )
+            )
+            lines.insert(i, f":vartype {attr_name}: {formatted}")
+            i += 2
+        else:
+            i += 1
 
 
 def _extract_doc_description(annotation: Any) -> str | None:

--- a/src/sphinx_autodoc_typehints/_resolver/__init__.py
+++ b/src/sphinx_autodoc_typehints/_resolver/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ._attrs import backfill_attrs_annotations
+from ._instance_vars import get_instance_var_annotations
 from ._type_comments import backfill_type_hints
 from ._type_hints import get_all_type_hints
 from ._util import collect_documented_type_aliases, get_obj_location
@@ -12,5 +13,6 @@ __all__ = [
     "backfill_type_hints",
     "collect_documented_type_aliases",
     "get_all_type_hints",
+    "get_instance_var_annotations",
     "get_obj_location",
 ]

--- a/src/sphinx_autodoc_typehints/_resolver/_instance_vars.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_instance_vars.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from typing import Any
+
+
+def get_instance_var_annotations(cls: type) -> dict[str, Any]:
+    """Extract instance variable annotations from ``__init__`` by walking its AST.
+
+    ``self.x: T = ...`` is not stored in ``cls.__annotations__`` at runtime, so
+    ``typing.get_type_hints`` cannot see it — AST inspection is the only option.
+    Only top-level statements of ``__init__`` are scanned to avoid picking up
+    annotations from nested functions.
+    """
+    init = cls.__init__
+    if init is object.__init__:
+        return {}
+    try:
+        source = textwrap.dedent(inspect.getsource(init))
+        tree = ast.parse(source)
+    except (OSError, TypeError, SyntaxError, IndentationError):
+        return {}
+
+    raw: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__":
+            self_name = node.args.args[0].arg if node.args.args else "self"
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.AnnAssign)
+                    and isinstance(stmt.target, ast.Attribute)
+                    and isinstance(stmt.target.value, ast.Name)
+                    and stmt.target.value.id == self_name
+                ):
+                    raw[stmt.target.attr] = ast.unparse(stmt.annotation)
+            break
+
+    if not raw:
+        return {}
+
+    module = inspect.getmodule(cls)
+    globalns: dict[str, Any] = vars(module) if module is not None else {}
+    resolved: dict[str, Any] = {}
+    for attr_name, ann_str in raw.items():
+        try:
+            resolved[attr_name] = eval(ann_str, globalns)  # noqa: S307
+        except Exception:  # noqa: BLE001
+            resolved[attr_name] = ann_str
+    return resolved
+
+
+__all__ = ["get_instance_var_annotations"]

--- a/src/sphinx_autodoc_typehints/_resolver/_instance_vars.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_instance_vars.py
@@ -7,7 +7,8 @@ from typing import Any
 
 
 def get_instance_var_annotations(cls: type) -> dict[str, Any]:
-    """Extract instance variable annotations from ``__init__`` by walking its AST.
+    """
+    Extract instance variable annotations from ``__init__`` by walking its AST.
 
     ``self.x: T = ...`` is not stored in ``cls.__annotations__`` at runtime, so
     ``typing.get_type_hints`` cannot see it — AST inspection is the only option.

--- a/tests/test_resolver/test_instance_vars.py
+++ b/tests/test_resolver/test_instance_vars.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from sphinx_autodoc_typehints._resolver._instance_vars import get_instance_var_annotations
+
+
+class _Simple:
+    def __init__(self, bar: str = "baz") -> None:
+        self.bar: str = bar
+
+
+class _Multi:
+    def __init__(self) -> None:
+        self.x: int = 0
+        self.y: str = ""
+        self.z: float = 0.0
+
+
+class _NoAnnotations:
+    def __init__(self) -> None:
+        self.x = 0
+
+
+class _NestedFunction:
+    def __init__(self) -> None:
+        self.outer: int = 0
+
+        def inner() -> None:
+            fake_self_attr: str = ""  # noqa: F841
+
+        inner()
+
+
+class _ComplexTypes:
+    def __init__(self) -> None:
+        self.items: list[str] = []
+        self.mapping: dict[str, int] = {}
+        self.maybe: Optional[int] = None
+
+
+class _NoInit:
+    pass
+
+
+def test_basic_instance_var() -> None:
+    assert _Simple().bar == "baz"
+    assert get_instance_var_annotations(_Simple) == {"bar": str}
+
+
+def test_multiple_instance_vars() -> None:
+    assert _Multi().x == 0
+    assert get_instance_var_annotations(_Multi) == {"x": int, "y": str, "z": float}
+
+
+def test_no_annotations_in_init() -> None:
+    assert _NoAnnotations().x == 0
+    assert get_instance_var_annotations(_NoAnnotations) == {}
+
+
+def test_nested_function_annotations_ignored() -> None:
+    assert _NestedFunction().outer == 0
+    result = get_instance_var_annotations(_NestedFunction)
+    assert result == {"outer": int}
+    assert "fake_self_attr" not in result
+
+
+@pytest.mark.parametrize(
+    ("cls", "attr", "expected"),
+    [
+        pytest.param(_ComplexTypes, "items", list[str], id="list"),
+        pytest.param(_ComplexTypes, "mapping", dict[str, int], id="dict"),
+        pytest.param(_ComplexTypes, "maybe", Optional[int], id="optional"),
+    ],
+)
+def test_complex_types(cls: type, attr: str, expected: object) -> None:
+    cls()  # cover __init__
+    result = get_instance_var_annotations(cls)
+    assert result[attr] == expected
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        pytest.param(_NoInit, id="no_init"),
+        pytest.param(object, id="object_itself"),
+    ],
+)
+def test_no_instance_vars(cls: type) -> None:
+    assert get_instance_var_annotations(cls) == {}

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -602,3 +602,104 @@ def test_wrong_module_path(app: SphinxTestApp, status: StringIO, warning: String
 
     assert "build succeeded" in status.getvalue()
     assert not warning.getvalue().strip()
+
+
+class _IvarClass:
+    """Class with instance variable docs.
+
+    :ivar bar: the bar value
+    :ivar count: the count
+    """
+
+    def __init__(self, bar: str = "baz", count: int = 0) -> None:
+        self.bar: str = bar
+        self.count: int = count
+
+
+class _IvarWithExistingVartype:
+    """Class with pre-existing :vartype:.
+
+    :ivar bar: the bar value
+    :vartype bar: str
+    """
+
+    def __init__(self) -> None:
+        self.bar: str = ""
+
+
+class _IvarInlineType:
+    """Class with inline-typed :ivar:.
+
+    :ivar str bar: the bar value
+    """
+
+    def __init__(self) -> None:
+        self.bar: str = ""
+
+
+class _IvarNoAnnotation:
+    """Class with ivar but no annotation.
+
+    :ivar bar: the bar value
+    """
+
+    def __init__(self) -> None:
+        self.bar = ""
+
+
+def test_ivar_type_injected() -> None:
+    assert _IvarClass().bar == "baz"  # instantiate to cover __init__
+    lines = [":ivar bar: the bar value", ":ivar count: the count"]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarClass", _IvarClass, None, lines)
+    assert any(line.startswith(":vartype bar:") and "str" in line for line in lines)
+    assert any(line.startswith(":vartype count:") and "int" in line for line in lines)
+
+
+def test_ivar_vartype_inserted_before_ivar() -> None:
+    lines = [":ivar bar: the bar value"]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarClass", _IvarClass, None, lines)
+    bar_idx = lines.index(":ivar bar: the bar value")
+    vartype_idx = next(i for i, line in enumerate(lines) if line.startswith(":vartype bar:"))
+    assert vartype_idx < bar_idx
+
+
+@pytest.mark.parametrize(
+    ("cls", "lines"),
+    [
+        pytest.param(
+            _IvarWithExistingVartype,
+            [":ivar bar: the bar value", ":vartype bar: str"],
+            id="existing_vartype",
+        ),
+        pytest.param(
+            _IvarInlineType,
+            [":ivar str bar: the bar value"],
+            id="inline_type",
+        ),
+    ],
+)
+def test_ivar_vartype_not_duplicated(cls: type, lines: list[str]) -> None:
+    cls()  # cover __init__
+    app = make_docstring_app()
+    process_docstring(app, "class", cls.__name__, cls, None, lines)
+    assert sum(1 for line in lines if line.startswith(":vartype bar:")) <= 1
+
+
+def test_ivar_without_annotation_no_vartype() -> None:
+    assert not _IvarNoAnnotation().bar  # cover __init__
+    lines = [":ivar bar: the bar value"]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarNoAnnotation", _IvarNoAnnotation, None, lines)
+    assert not any(line.startswith(":vartype bar:") for line in lines)
+
+
+def test_ivar_injection_only_for_class() -> None:
+    def func(x: str) -> str:  # needs annotations so process_docstring does not short-circuit
+        return x  # pragma: no cover
+
+    lines = [":ivar bar: should not be processed"]
+    app = make_docstring_app(typehints_document_rtype=False)
+    process_docstring(app, "function", "func", func, None, lines)
+    assert not any(line.startswith(":vartype bar:") for line in lines)


### PR DESCRIPTION
When a class documents instance variables with `:ivar name:` in its docstring and annotates them as `self.name: T = ...` in `__init__`, the `:vartype:` field was never populated. Users had to duplicate type information manually — once in the annotation and once in the docstring. Closes #151.

The core obstacle is that `self.x: T = ...` inside a method body is not stored in `cls.__annotations__` at runtime; Python evaluates and discards the annotation, so `typing.get_type_hints` cannot see it. ✨ The solution is to inspect the AST of `__init__` directly — only its top-level statements, to avoid picking up annotations from nested functions — unparse each annotation back to a string, and resolve it against the module globals.

When `process_docstring` runs for a class, it now pairs this extraction with the existing docstring scan: for each `:ivar name:` field that has no inline type (`:ivar T name:`) and no explicit `:vartype name:` already present, it inserts a `:vartype:` line formatted through the same pipeline as parameter types. Fields that already carry type information are left untouched.