### PR TITLE
🐛 fix(intersphinx): skip union aliases in type mapping

### DIFF
--- a/src/sphinx_autodoc_typehints/_intersphinx.py
+++ b/src/sphinx_autodoc_typehints/_intersphinx.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import types as _types
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -32,8 +33,17 @@ def build_type_mapping(env: BuildEnvironment) -> dict[str, str]:
             try:
                 mod = importlib.import_module(mod_path)
                 obj = getattr(mod, attr_name)
+                # Union instances borrow __module__/__qualname__ from their type class,
+                # so every X|Y alias resolves to the same "types.UnionType"/"typing.Union"
+                # path and would corrupt all union annotations in the rendered docs.
+                if isinstance(obj, _types.UnionType):
+                    continue
                 internal_path = f"{obj.__module__}.{obj.__qualname__}"
             except Exception:  # noqa: BLE001, S112
+                continue
+            # typing.Union[X, Y] aliases on Python <3.14 are not types.UnionType instances
+            # but still resolve to "typing.Union"; guard against those and any edge cases.
+            if internal_path in {"types.UnionType", "typing.Union"}:
                 continue
             if internal_path != documented_name:
                 candidates.append((internal_path, documented_name))

--- a/tests/test_intersphinx_mapping.py
+++ b/tests/test_intersphinx_mapping.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
+import sys
 import threading
+import types as _types
+import typing
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import create_autospec
 
+import pytest
 from sphinx.config import Config
 
 from sphinx_autodoc_typehints import format_annotation
 from sphinx_autodoc_typehints._intersphinx import build_type_mapping
 
 if TYPE_CHECKING:
-    import pytest
     from sphinx.environment import BuildEnvironment
 
 
@@ -110,3 +113,22 @@ def test_format_annotation_without_mapping() -> None:
     conf = create_autospec(Config, always_use_bars_union=False)
     result = format_annotation(threading.local, conf)
     assert result == ":py:class:`~_thread._local`"
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        pytest.param(bytes | memoryview, id="X|Y"),
+        pytest.param(typing.Union[bytes, memoryview], id="Union[X,Y]"),
+    ],
+)
+def test_build_type_mapping_skips_union_alias(monkeypatch: pytest.MonkeyPatch, alias: object) -> None:
+    # Union instances all resolve to the same union-type class path, so including
+    # them in the mapping would remap every union annotation in the docs.
+    mypkg = _types.ModuleType("mypkg")
+    mypkg.MyAlias = alias  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mypkg", mypkg)
+    inventory_data: dict[str, dict[str, Any]] = {"py:data": {"mypkg.MyAlias": ("", "", "", "")}}
+    result = build_type_mapping(_make_env(inventory_data))
+    assert "types.UnionType" not in result
+    assert "typing.Union" not in result


### PR DESCRIPTION
When a dependency documents a type alias that is a union (e.g. `MyAlias = bytes | memoryview`) and that alias appears in an intersphinx inventory, `build_type_mapping()` was inserting a spurious entry mapping `"types.UnionType"` or `"typing.Union"` to `"pkg.MyAlias"`. Because all union instances borrow `__module__`/`__qualname__` from their type class rather than carrying a unique identity, every `X | Y` annotation in the rendered docs would then appear as `MyAlias[int, str]` instead of `int | str`. 🐛

The fix adds two guards in `build_type_mapping()`. An `isinstance(obj, types.UnionType)` check skips union instances on all supported Python versions (on 3.14+, `types.UnionType is typing.Union`, so this catches both `X | Y` and `Union[X, Y]` forms in one shot). A second check on the computed `internal_path` handles `typing.Union[X, Y]` aliases on Python 3.10–3.13, where those objects are not `types.UnionType` instances but still resolve to `"typing.Union"`.

No existing behaviour changes — the only entries dropped from the mapping are ones that were never valid remappings to begin with. ✨