### PR TITLE
🐛 fix(resolver): surface hints for @no_type_check targets

### DIFF
--- a/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
@@ -109,7 +109,13 @@ def _get_type_hint(
     _resolve_type_guarded_imports(autodoc_mock_imports, obj)
     localns = _build_localns(obj, localns)
     try:
-        result = get_type_hints(obj, None, localns, include_extras=True)
+        if getattr(obj, "__no_type_check__", False):
+            # typing.get_type_hints() unconditionally returns {} for @typing.no_type_check
+            # targets; inspect.get_annotations() has no such guard, so use it to still surface
+            # annotations in the rendered docs (see issue #680).
+            result = inspect.get_annotations(obj, locals=localns, eval_str=True)
+        else:
+            result = get_type_hints(obj, None, localns, include_extras=True)
     except (AttributeError, TypeError, RecursionError) as exc:
         if (
             isinstance(exc, TypeError) and _future_annotations_imported(obj) and "unsupported operand type" in str(exc)

--- a/tests/test_resolver/test_no_type_check.py
+++ b/tests/test_resolver/test_no_type_check.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import typing
+
+from sphinx_autodoc_typehints._resolver._type_hints import _get_type_hint, get_all_type_hints
+
+
+@typing.no_type_check
+def _decorated_function(x: int, y: str) -> bool:
+    return bool(x) and bool(y)
+
+
+@typing.no_type_check
+class _DecoratedClass:
+    def method(self, value: int) -> str:  # noqa: PLR6301
+        return str(value)
+
+
+class _Target:
+    pass
+
+
+@typing.no_type_check
+def _deferred_forward_ref(obj: _Target) -> _Target:
+    return obj
+
+
+def test_no_type_check_function_still_resolves_hints() -> None:
+    result = get_all_type_hints([], _decorated_function, "_decorated_function", {})
+    assert result == {"x": int, "y": str, "return": bool}
+
+
+def test_no_type_check_method_still_resolves_hints() -> None:
+    result = _get_type_hint([], "_DecoratedClass.method", _DecoratedClass.method, {})
+    assert result == {"value": int, "return": str}
+
+
+def test_no_type_check_resolves_future_string_annotations() -> None:
+    result = _get_type_hint([], "_deferred_forward_ref", _deferred_forward_ref, {})
+    assert result == {"obj": _Target, "return": _Target}


### PR DESCRIPTION
`typing.get_type_hints()` returns an empty dict whenever the target carries `__no_type_check__`, so any function a user decorates with `@typing.no_type_check` to opt out of runtime type checking also loses its annotations in the rendered docs. Users were forced to apply the decorator conditionally around doc builds to keep their API reference intact.

The resolver now checks for `__no_type_check__` before calling `typing.get_type_hints()` and routes flagged targets through `inspect.get_annotations(eval_str=True)` instead. `inspect.get_annotations` has no such guard and still evaluates string annotations produced by `from __future__ import annotations`, so forward references in decorated functions resolve the same way they do on the normal path. Everything else (the existing `get_type_hints` call, its `localns` handling, and all of the fallback paths for stubs, type comments, and `NameError`) is left untouched.

Fixes #680