### PR TITLE
🐛 fix(ivar): tolerate malformed :ivar field entries

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 import types
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -413,28 +414,45 @@ def _inject_rtype(  # noqa: PLR0913, PLR0917
     fmt.inject_rtype(lines, formatted_annotation, r, use_rtype=app.config.typehints_use_rtype)
 
 
+# Matches a well-formed Sphinx ``:ivar ...:`` field list entry. Supports both
+# ``:ivar name:`` and the inline-typed ``:ivar <type> name:`` grammar. The
+# optional type is lazy so the final whitespace-delimited token before the
+# closing colon is always captured as the attribute name. Anything that does
+# not match (empty name, missing closing colon, bare ``:ivar :``) is skipped
+# rather than crashing the parser — see issue #683.
+_IVAR_FIELD_RE = re.compile(
+    r"""
+    ^:ivar                       # literal field marker
+    (?:\s+(?P<type>\S.*?))?      # optional inline type expression
+    \s+(?P<name>\w+)             # attribute name (Python identifier)
+    \s*:                         # closing colon of the field name
+    """,
+    re.VERBOSE,
+)
+
+
 def _inject_ivar_types(ivar_annotations: dict[str, Any], app: Sphinx, lines: list[str]) -> None:
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        if not line.startswith(":ivar "):
-            i += 1
+    line_index = 0
+    while line_index < len(lines):
+        match = _IVAR_FIELD_RE.match(lines[line_index])
+        if match is None:
+            line_index += 1
             continue
-        _ivar, *type_tokens, attr_name = line.split(":", maxsplit=2)[1].split()
-        has_inline_type = bool(type_tokens)
-        has_vartype = any(ln.startswith(f":vartype {attr_name}:") for ln in lines)
-        if not has_inline_type and not has_vartype and attr_name in ivar_annotations:
-            formatted = add_type_css_class(
-                format_annotation(
-                    ivar_annotations[attr_name],
-                    app.config,
-                    short_literals=app.config.python_display_short_literal_types,
-                )
+        attr_name = match["name"]
+        has_inline_type = match["type"] is not None
+        has_vartype = any(existing.startswith(f":vartype {attr_name}:") for existing in lines)
+        if has_inline_type or has_vartype or attr_name not in ivar_annotations:
+            line_index += 1
+            continue
+        formatted = add_type_css_class(
+            format_annotation(
+                ivar_annotations[attr_name],
+                app.config,
+                short_literals=app.config.python_display_short_literal_types,
             )
-            lines.insert(i, f":vartype {attr_name}: {formatted}")
-            i += 2
-        else:
-            i += 1
+        )
+        lines.insert(line_index, f":vartype {attr_name}: {formatted}")
+        line_index += 2
 
 
 def _extract_doc_description(annotation: Any) -> str | None:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -703,3 +703,90 @@ def test_ivar_injection_only_for_class() -> None:
     app = make_docstring_app(typehints_document_rtype=False)
     process_docstring(app, "function", "func", func, None, lines)
     assert not any(line.startswith(":vartype bar:") for line in lines)
+
+
+@pytest.mark.parametrize(
+    "malformed_line",
+    [
+        pytest.param(":ivar :", id="single_space_empty_name"),
+        pytest.param(":ivar  :", id="double_space_empty_name"),
+        pytest.param(":ivar   :", id="triple_space_empty_name"),
+        pytest.param(":ivar ", id="trailing_space_no_colon"),
+        pytest.param(":ivar bar", id="no_closing_colon"),
+        pytest.param(":ivar bar body", id="no_closing_colon_with_body"),
+    ],
+)
+def test_ivar_injection_skips_malformed_line(malformed_line: str) -> None:
+    """Regression: malformed ``:ivar ...`` lines must not crash the parser (issue #683)."""
+    assert _IvarClass().bar == "baz"  # cover __init__
+    lines = [malformed_line]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarClass", _IvarClass, None, lines)
+    assert lines == [malformed_line]
+
+
+def test_ivar_injection_survives_mixed_malformed_and_valid_lines() -> None:
+    """A crashing malformed entry must not block injection of valid sibling entries."""
+    assert _IvarClass().bar == "baz"  # cover __init__
+    lines = [
+        ":ivar :",
+        ":ivar bar: the bar value",
+        ":ivar  :",
+        ":ivar count: the count",
+    ]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarClass", _IvarClass, None, lines)
+    assert ":ivar :" in lines
+    assert ":ivar  :" in lines
+    assert any(line.startswith(":vartype bar:") and "str" in line for line in lines)
+    assert any(line.startswith(":vartype count:") and "int" in line for line in lines)
+
+
+@pytest.mark.parametrize(
+    "non_field_line",
+    [
+        pytest.param(":ivarname: not a real field", id="no_space_after_ivar"),
+        pytest.param(":ivars bar: pluralised keyword", id="pluralised_ivar"),
+    ],
+)
+def test_ivar_injection_ignores_non_ivar_field(non_field_line: str) -> None:
+    """Lines that merely share the ``:ivar`` prefix must not be mistaken for fields."""
+    assert _IvarClass().bar == "baz"  # cover __init__
+    lines = [non_field_line]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarClass", _IvarClass, None, lines)
+    assert lines == [non_field_line]
+
+
+@pytest.mark.parametrize(
+    "valid_line",
+    [
+        pytest.param(":ivar\tbar: the bar value", id="tab_separator"),
+        pytest.param(":ivar   bar: the bar value", id="multi_space_separator"),
+        pytest.param(":ivar  bar:  the bar value", id="multi_space_around_body"),
+    ],
+)
+def test_ivar_injection_accepts_whitespace_variants(valid_line: str) -> None:
+    """Non-ASCII-single-space whitespace between ``:ivar`` and name must still match."""
+    assert _IvarClass().bar == "baz"  # cover __init__
+    lines = [valid_line]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarClass", _IvarClass, None, lines)
+    assert any(line.startswith(":vartype bar:") and "str" in line for line in lines)
+
+
+@pytest.mark.parametrize(
+    "inline_typed_line",
+    [
+        pytest.param(":ivar Dict[str, int] bar: the bar value", id="dict_str_int"),
+        pytest.param(":ivar Callable[[int], str] bar: the bar value", id="callable"),
+        pytest.param(":ivar tuple[int, ...] bar: the bar value", id="tuple_ellipsis"),
+    ],
+)
+def test_ivar_injection_accepts_parameterised_inline_type(inline_typed_line: str) -> None:
+    """Inline types containing spaces still count as inline-typed and suppress injection."""
+    assert _IvarClass().bar == "baz"  # cover __init__
+    lines = [inline_typed_line]
+    app = make_docstring_app()
+    process_docstring(app, "class", "_IvarClass", _IvarClass, None, lines)
+    assert not any(line.startswith(":vartype bar:") for line in lines)


### PR DESCRIPTION
A docstring line starting with `:ivar` but lacking an attribute name (a bare `:ivar :`, for instance) crashes `process_docstring` with `not enough values to unpack (expected at least 2, got 1)` and takes the entire Sphinx build down with it. This is how issue #683 reached xclim's ReadTheDocs pipeline on `sphinx-autodoc-typehints 3.10.x`: one malformed field anywhere in the documented tree halts the build before any other page can be rendered. 🐛

Parsing of `:ivar` field entries now goes through a verbose regex that matches the two well-formed grammars Sphinx documents (`:ivar name:` and `:ivar <type> name:`) and skips anything else. The previous `split(":")` pipeline assumed every `:ivar` line contained at least a keyword and a name token, which held for every shape covered by the tests added alongside #678 but not for the empty-name shapes that upstream docstring converters can emit. Treating malformed entries as "not our field" keeps the injection purely additive: when a line is unrecognisable we leave it in place and move on, preserving both the docstring content and the rest of the build.

End-to-end validation against a cloned xclim tree reproduces the exact `not enough values to unpack` crash on the current parser and confirms the regex path walks the same tree cleanly, with the `ivar` test module covering malformed, non-`ivar` prefix, whitespace-variant, and parameterised inline-type cases.