### PR TITLE
Show version in error tracebacks

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -495,7 +495,7 @@ def sphinx_autodoc_typehints_type_role(
     return [n], []
 
 
-def setup(app: Sphinx) -> dict[str, bool]:
+def setup(app: Sphinx) -> dict[str, bool | str]:
     app.add_config_value("always_document_param_types", False, "html")  # noqa: FBT003
     app.add_config_value("typehints_fully_qualified", False, "env")  # noqa: FBT003
     app.add_config_value("typehints_document_rtype", True, "env")  # noqa: FBT003
@@ -514,7 +514,11 @@ def setup(app: Sphinx) -> dict[str, bool]:
     app.connect("autodoc-process-signature", process_signature)
     app.connect("autodoc-process-docstring", process_docstring)
     install_patches(app)
-    return {"parallel_read_safe": True, "parallel_write_safe": True}
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 
 __all__ = [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import inspect
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 from conftest import make_docstring_app, make_sig_app
+from sphinx.application import Sphinx
+from sphinx.config import Config
 
 import sphinx_autodoc_typehints as sat
-from sphinx_autodoc_typehints import _inject_overload_signatures, process_docstring, process_signature
+from sphinx_autodoc_typehints import (
+    __version__,
+    _inject_overload_signatures,
+    process_docstring,
+    process_signature,
+    setup,
+)
 from sphinx_autodoc_typehints._resolver._util import get_obj_location
 from sphinx_autodoc_typehints.patches import _OVERLOADS_CACHE
 
@@ -288,3 +296,13 @@ def test_process_docstring_strips_complex_inline_param_type() -> None:
     type_lines = [line for line in lines if line.startswith(":type fp:")]
     assert len(type_lines) == 1
     assert "int" in type_lines[0]
+
+
+def test_setup_returns_version() -> None:
+    """setup() returns metadata dict with version from __version__."""
+    app = create_autospec(Sphinx)
+    app.config = create_autospec(Config)
+    result = setup(app)
+    assert result["version"] == __version__
+    assert result["parallel_read_safe"] is True
+    assert result["parallel_write_safe"] is True


### PR DESCRIPTION
Supersedes #554, by adding a missing test that was requested by @gaborbernat at https://github.com/tox-dev/sphinx-autodoc-typehints/pull/554#pullrequestreview-3063287022

Add the extension version to the plugin metadata so Sphinx can report it on traceback.

Without it, `sphinx-autodoc-typehints` is reported with an unknown version. See for example:
```txt
Versions
========

* Platform:         darwin; (macOS-15.5-arm64-64bit)
* Python version:   3.11.11 (CPython)
* Sphinx version:   8.2.3
* Docutils version: 0.21.2
* Jinja2 version:   3.1.6
* Pygments version: 2.19.2

Last Messages
=============

(...)

Loaded Extensions
=================

* sphinx.ext.mathjax (8.2.3)
* alabaster (1.0.0)
* sphinxcontrib.applehelp (2.0.0)
* sphinxcontrib.devhelp (2.0.0)
* sphinxcontrib.htmlhelp (2.1.0)
* sphinxcontrib.serializinghtml (2.0.0)
* sphinxcontrib.qthelp (2.0.0)
* sphinx.ext.autodoc.preserve_defaults (8.2.3)
* sphinx.ext.autodoc.type_comment (8.2.3)
* sphinx.ext.autodoc.typehints (8.2.3)
* sphinx.ext.autodoc (8.2.3)
* sphinx.ext.todo (8.2.3)
* sphinx.ext.intersphinx (8.2.3)
* sphinx.ext.viewcode (8.2.3)
* sphinx_copybutton (0.5.2)
* sphinx_design (0.6.1)
* sphinx_issues (5.0.1)
* sphinxext.opengraph (0.10.0)
* myst_parser (4.0.1)
* sphinx.ext.autosectionlabel (8.2.3)
* sphinx_autodoc_typehints (unknown version)
* click_extra.sphinx (5.1.0)
* sphinxcontrib.mermaid (8.2.3)
* furo (2025.07.19)
* sphinx_basic_ng (1.0.0.beta2)

Traceback
=========

(...)
```