### PR TITLE
Support PEP 695 `type` statement and python 3.12+ `TypeAliasType`

### DIFF
--- a/src/sphinx_autodoc_typehints/_annotations.py
+++ b/src/sphinx_autodoc_typehints/_annotations.py
@@ -119,6 +119,12 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
             for candidate in candidates:
                 if candidate in py_domain.objects and py_domain.objects[candidate].objtype == "type":
                     return f":py:type:`{prefix}{candidate}`"
+            # Handle external type aliases
+            canonical = _get_canonical_type_alias_name(annotation)
+            current_top = module_prefix.split(".")[0] if module_prefix else ""
+            if canonical and canonical.split(".")[0] != current_top:
+                full_name = _fixup_module_name(config, canonical.rpartition(".")[0]) + "." + annotation.__name__
+                return f":py:obj:`{prefix}{full_name}`"
         return format_annotation(annotation.__value__, config, short_literals=short_literals)
 
     try:
@@ -309,6 +315,34 @@ def _get_types_type(obj: Any) -> str | None:
 
 def _is_newtype(annotation: Any) -> bool:
     return isinstance(annotation, NewType)
+
+
+def _get_canonical_type_alias_name(annotation: TypeAliasType) -> str:
+    """
+    Get canonical public qualified name for a TypeAliasType.
+
+    For types defined in private modules (e.g. ``numpy._typing.ArrayLike``),
+    search ``sys.modules`` for a public re-export
+    (e.g. ``numpy.typing.ArrayLike``).
+    """
+    module = getattr(annotation, "__module__", "") or ""
+    name = getattr(annotation, "__name__", "") or ""
+    if not module or not name:
+        return ""
+    if not any(part.startswith("_") for part in module.split(".")):
+        return f"{module}.{name}"
+    top_pkg = module.split(".")[0]
+    for mod_name in sorted(sys.modules):
+        if not mod_name.startswith(top_pkg):
+            continue
+        mod = sys.modules[mod_name]
+        if not isinstance(mod, types.ModuleType):
+            continue
+        if any(part.startswith("_") for part in mod_name.split(".")):
+            continue
+        if getattr(mod, name, None) is annotation:
+            return f"{mod_name}.{name}"
+    return f"{module}.{name}"
 
 
 def unescape(escaped: str) -> str:

--- a/src/sphinx_autodoc_typehints/_annotations.py
+++ b/src/sphinx_autodoc_typehints/_annotations.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
     from sphinx.config import Config
 
+from typing import TypeAliasType
+
 _PYDATA_ANNOTS_TYPING = {
     "Any",
     "AnyStr",
@@ -101,6 +103,23 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
         if isinstance(annotation, MyTypeAliasForwardRef) and annotation.crossref:
             return f":py:type:`{prefix}{annotation.name}`"
         return annotation.name
+
+    if isinstance(annotation, TypeAliasType):
+        fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
+        prefix = "" if fully_qualified else "~"
+        if (env := getattr(config, "_typehints_env", None)) is not None:
+            py_domain = env.get_domain("py")
+            module_prefix = getattr(config, "_typehints_module_prefix", "")
+            prefix_parts = module_prefix.split(".") if module_prefix else []
+            # Walk up the module prefix to find a matching type in the py domain
+            candidates = [
+                f"{'.'.join(prefix_parts[:n])}.{annotation.__name__}" for n in range(len(prefix_parts), 0, -1)
+            ]
+            candidates.append(annotation.__name__)
+            for candidate in candidates:
+                if candidate in py_domain.objects and py_domain.objects[candidate].objtype == "type":
+                    return f":py:type:`{prefix}{candidate}`"
+        return format_annotation(annotation.__value__, config, short_literals=short_literals)
 
     try:
         module = get_annotation_module(annotation)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -25,6 +25,7 @@ from typing import (  # noqa: UP035
     Required,
     Tuple,
     Type,
+    TypeAliasType,
     TypeVar,
     Union,
 )
@@ -40,6 +41,7 @@ from sphinx_autodoc_typehints import (
     get_annotation_class_name,
     get_annotation_module,
 )
+from sphinx_autodoc_typehints._annotations import _get_canonical_type_alias_name
 
 if TYPE_CHECKING:
     from sphobjinv import Inventory
@@ -569,3 +571,34 @@ def test_get_annotation_args_literal_values() -> None:
 def test_get_annotation_args_generic() -> None:
     result = get_annotation_args(Generic[T], "typing", "Generic")
     assert result == (T,)
+
+
+def test_get_canonical_type_alias_name_public_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    pub = types.ModuleType("mypkg")
+    exec("type MyAlias = str | int", pub.__dict__)  # noqa: S102
+    alias: TypeAliasType = pub.__dict__["MyAlias"]
+    monkeypatch.setitem(sys.modules, "mypkg", pub)
+    assert _get_canonical_type_alias_name(alias) == "mypkg.MyAlias"
+
+
+def test_get_canonical_type_alias_name_private_to_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    priv = types.ModuleType("extpkg._priv")
+    exec("type ExtAlias = str | int", priv.__dict__)  # noqa: S102
+    alias: TypeAliasType = priv.__dict__["ExtAlias"]
+    pub = types.ModuleType("extpkg")
+    pub.ExtAlias = alias  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "extpkg._priv", priv)
+    monkeypatch.setitem(sys.modules, "extpkg", pub)
+    assert _get_canonical_type_alias_name(alias) == "extpkg.ExtAlias"
+
+
+def test_get_canonical_type_alias_name_no_public_reexport(monkeypatch: pytest.MonkeyPatch) -> None:
+    priv = types.ModuleType("extpkg2._priv")
+    exec("type ExtAlias2 = str | int", priv.__dict__)  # noqa: S102
+    alias: TypeAliasType = priv.__dict__["ExtAlias2"]
+    monkeypatch.setitem(sys.modules, "extpkg2._priv", priv)
+    assert _get_canonical_type_alias_name(alias) == "extpkg2._priv.ExtAlias2"
+
+
+def test_get_canonical_type_alias_name_no_module() -> None:
+    assert not _get_canonical_type_alias_name(object())

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -598,7 +598,3 @@ def test_get_canonical_type_alias_name_no_public_reexport(monkeypatch: pytest.Mo
     alias: TypeAliasType = priv.__dict__["ExtAlias2"]
     monkeypatch.setitem(sys.modules, "extpkg2._priv", priv)
     assert _get_canonical_type_alias_name(alias) == "extpkg2._priv.ExtAlias2"
-
-
-def test_get_canonical_type_alias_name_no_module() -> None:
-    assert not _get_canonical_type_alias_name(object())

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -45,6 +45,7 @@ exec(  # noqa: S102
 
             :return: the thing
             \"\"\"
+            ...
 
     class FooStringOrInt(Foo[StringOrInt]):
         \"\"\"A subclass of Foo with StringOrInt type param.\"\"\"
@@ -55,6 +56,7 @@ exec(  # noqa: S102
             :param thing: the thing
             :return: the thing
             \"\"\"
+            ...
 
     class Multi[K, V]:
         \"\"\"A class with multiple type params.\"\"\"
@@ -72,7 +74,6 @@ exec(  # noqa: S102
         :param x: input
         \"\"\"
         return x
-
     """),
     _mod_pep695.__dict__,
 )
@@ -134,7 +135,6 @@ def test_pep695_function_type_params(
     assert "Cannot resolve forward reference" not in warning.getvalue()
 
 
-# TypeAliasType tests
 @pytest.mark.sphinx("text", testroot="integration")
 def test_pep695_type_alias_in_function_undocumented(
     app: SphinxTestApp,

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from sphinx.testing.util import SphinxTestApp
 
-_mod_pep695 = types.ModuleType("_mod_pep695")
+_mod_pep695 = types.ModuleType("mod")
 _mod_pep695.__file__ = __file__
 exec(  # noqa: S102
     dedent("""\
@@ -45,7 +45,16 @@ exec(  # noqa: S102
 
             :return: the thing
             \"\"\"
-            ...
+
+    class FooStringOrInt(Foo[StringOrInt]):
+        \"\"\"A subclass of Foo with StringOrInt type param.\"\"\"
+
+        def set(self, thing: StringOrInt) -> StringOrInt:
+            \"\"\"Set the thing.
+
+            :param thing: the thing
+            :return: the thing
+            \"\"\"
 
     class Multi[K, V]:
         \"\"\"A class with multiple type params.\"\"\"
@@ -127,12 +136,15 @@ def test_pep695_function_type_params(
 
 # TypeAliasType tests
 @pytest.mark.sphinx("text", testroot="integration")
-def test_pep695_type_aliases_undocumented(
+def test_pep695_type_alias_in_function_undocumented(
     app: SphinxTestApp,
     status: StringIO,
     warning: StringIO,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Test that PEP 695 type aliases in function signatures
+    are rendered as their literal types when the type aliases are
+    not documented."""
     (Path(app.srcdir) / "index.rst").write_text(".. autofunction:: mod.type_alias_func")
     monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
     app.build()
@@ -158,12 +170,15 @@ def test_pep695_type_aliases_undocumented(
 
 
 @pytest.mark.sphinx("text", testroot="integration")
-def test_pep695_type_aliases_documented(
+def test_pep695_type_alias_in_function_documented(
     app: SphinxTestApp,
     status: StringIO,
     warning: StringIO,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Test that PEP 695 type aliases in function signatures
+    are rendered as their documented type names when the type aliases
+    are documented."""
     (Path(app.srcdir) / "index.rst").write_text(
         dedent("""\
         .. py:type:: mod.IntList
@@ -204,5 +219,94 @@ def test_pep695_type_aliases_documented(
 
            Returns:
               String or integer
+        """).strip()
+    assert result.strip() == normalize_sphinx_text(expected)
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_type_alias_in_method_undocumented(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that PEP 695 type aliases in method signatures are
+    rendered as their literal types when the type aliases are not
+    documented."""
+    (Path(app.srcdir) / "index.rst").write_text(".. autoclass:: mod.FooStringOrInt\n   :members:")
+    monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert not warning.getvalue().strip()
+
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    expected = dedent("""\
+        class mod.FooStringOrInt(thing)
+
+           A subclass of Foo with StringOrInt type param.
+
+           set(thing)
+
+              Set the thing.
+
+              Parameters:
+                 **thing** ("str" | "int") -- the thing
+
+              Return type:
+                 "str" | "int"
+
+              Returns:
+                 the thing
+        """).strip()
+    assert result.strip() == normalize_sphinx_text(expected)
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_type_alias_in_method_documented(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that PEP 695 type aliases in method signatures are
+    rendered as their documented type names when the type aliases
+    are documented."""
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        .. py:type:: mod.StringOrInt
+
+           String or integer
+
+        .. autoclass:: mod.FooStringOrInt
+           :members:
+        """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert not warning.getvalue().strip()
+
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    expected = dedent("""\
+        type mod.StringOrInt
+
+           String or integer
+
+        class mod.FooStringOrInt(thing)
+
+           A subclass of Foo with StringOrInt type param.
+
+           set(thing)
+
+              Set the thing.
+
+              Parameters:
+                 **thing** ("StringOrInt") -- the thing
+
+              Return type:
+                 "StringOrInt"
+
+              Returns:
+                 the thing
         """).strip()
     assert result.strip() == normalize_sphinx_text(expected)

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
+from conftest import normalize_sphinx_text
 
 if TYPE_CHECKING:
     from io import StringIO
@@ -18,6 +19,17 @@ _mod_pep695.__file__ = __file__
 exec(  # noqa: S102
     dedent("""\
     from __future__ import annotations
+
+    type IntList = list[int]
+    type StringOrInt = str | int
+
+    def type_alias_func(x: IntList) -> StringOrInt:
+        \"\"\"Function using PEP 695 type aliases.
+
+        :param x: List of integers
+        :return: String or integer
+        \"\"\"
+        ...
 
     class Foo[T]:
         \"\"\"A generic class.\"\"\"
@@ -51,6 +63,7 @@ exec(  # noqa: S102
         :param x: input
         \"\"\"
         return x
+
     """),
     _mod_pep695.__dict__,
 )
@@ -110,3 +123,86 @@ def test_pep695_function_type_params(
     app.build()
     assert "build succeeded" in status.getvalue()
     assert "Cannot resolve forward reference" not in warning.getvalue()
+
+
+# TypeAliasType tests
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_type_aliases_undocumented(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(".. autofunction:: mod.type_alias_func")
+    monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert not warning.getvalue().strip()
+
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    expected = dedent("""\
+        mod.type_alias_func(x)
+
+           Function using PEP 695 type aliases.
+
+           Parameters:
+              **x** ("list"["int"]) -- List of integers
+
+           Return type:
+              "str" | "int"
+
+           Returns:
+              String or integer
+        """).strip()
+    assert result.strip() == normalize_sphinx_text(expected)
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_type_aliases_documented(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        dedent("""\
+        .. py:type:: mod.IntList
+
+           List of integers
+
+        .. py:type:: mod.StringOrInt
+
+           String or integer
+
+        .. autofunction:: mod.type_alias_func
+        """)
+    )
+    monkeypatch.setitem(sys.modules, "mod", _mod_pep695)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert not warning.getvalue().strip()
+
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    expected = dedent("""\
+        type mod.IntList
+
+           List of integers
+
+        type mod.StringOrInt
+
+           String or integer
+
+        mod.type_alias_func(x)
+
+           Function using PEP 695 type aliases.
+
+           Parameters:
+              **x** ("IntList") -- List of integers
+
+           Return type:
+              "StringOrInt"
+
+           Returns:
+              String or integer
+        """).strip()
+    assert result.strip() == normalize_sphinx_text(expected)

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -310,3 +310,45 @@ def test_pep695_type_alias_in_method_documented(
                  the thing
         """).strip()
     assert result.strip() == normalize_sphinx_text(expected)
+
+
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_external_type_alias(
+    app: SphinxTestApp,
+    status: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that external TypeAliasType renders as the alias name, not the expanded value."""
+    # Define an external type alias in a private module
+    ext_priv_mod = types.ModuleType("extpkg._priv")
+    exec("type ExtAlias = str | int", ext_priv_mod.__dict__)  # noqa: S102
+    ext_alias = ext_priv_mod.__dict__["ExtAlias"]
+    # Reexport the type alias in a public module
+    ext_pub_mod = types.ModuleType("extpkg")
+    ext_pub_mod.ExtAlias = ext_alias  # type: ignore[attr-defined]
+    # Import and use the external type alias in user module
+    user_mod = types.ModuleType("user_mod")
+    user_mod.__dict__["ExtAlias"] = ext_alias
+    exec(  # noqa: S102
+        dedent("""\
+        from __future__ import annotations
+
+        def ext_alias_func(x: ExtAlias) -> ExtAlias:
+            \"\"\"Function using external type alias.
+
+            :param x: the value
+            :return: the value
+            \"\"\"
+            ...
+        """),
+        user_mod.__dict__,
+    )
+
+    (Path(app.srcdir) / "index.rst").write_text(".. autofunction:: user_mod.ext_alias_func")
+    monkeypatch.setitem(sys.modules, "user_mod", user_mod)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    assert '"ExtAlias"' in result
+    assert '"str" | "int"' not in result


### PR DESCRIPTION
Closes #690 

This PR
- adds an `if isinstance(annotation, TypeAliasType):` branch in `format_annotation` to handle [typing.TypeAliasType](https://docs.python.org/3/library/typing.html#typing.TypeAliasType) introduced in python 3.12
  - the logic is similar to how `TypeAliasForwardRef` is currently handled, extending that same lookup to all intermediate prefix levels, so aliases documented anywhere in the module hierarchy resolve correctly
- adds, for external TypeAliasType (defined in a different top-level package), `_get_canonical_type_alias_name` which resolves the canonical public name
  - here we prefer public re-exports over private module paths (e.g. extpkg.ExtAlias over extpkg._priv.ExtAlias) 
  - this is used inside the `if isinstance(annotation, TypeAliasType):` branch to render a cross-reference instead of expanding to the underlying type(s)
- adds tests to cover
  - documented and undocumented `TypeAliasType` instances
  - local and external `TypeAliasType` instances 