### PR TITLE
🧪 test: fix PLW0717 try-clause statement limit

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -95,9 +95,9 @@ def test_inject_overload_unannotated_param_and_no_return() -> None:
         parameters=[inspect.Parameter("x", inspect.Parameter.POSITIONAL_OR_KEYWORD)],
     )
     _OVERLOADS_CACHE["test_mod"] = {"func": [sig]}
+    app = make_docstring_app()
+    lines: list[str] = []
     try:
-        app = make_docstring_app()
-        lines: list[str] = []
         result = _inject_overload_signatures(app, "function", "name", obj, lines)
         assert result is True
         joined = "\n".join(lines)

--- a/tests/test_resolver/test_type_hints.py
+++ b/tests/test_resolver/test_type_hints.py
@@ -207,15 +207,12 @@ def test_stub_annotations_not_polluted_on_repeated_calls(tmp_path: Path) -> None
         "from stubpkg._types import MyType\nclass Klass:\n    def method(self, x: MyType) -> None: ...\n"
     )
     sys.path.insert(0, str(tmp_path))
+    mod = importlib.import_module("stubpkg.mod")
+    _TYPE_GUARD_IMPORTS_RESOLVED.discard("stubpkg.mod")
+    my_type = importlib.import_module("stubpkg._types").MyType
     try:
-        mod = importlib.import_module("stubpkg.mod")
-        _TYPE_GUARD_IMPORTS_RESOLVED.discard("stubpkg.mod")
-
-        my_type = importlib.import_module("stubpkg._types").MyType
-
         result1 = get_all_type_hints([], mod.Klass.method, "stubpkg.mod.Klass.method", {})
         assert result1["x"] is my_type
-
         _TYPE_GUARD_IMPORTS_RESOLVED.discard("stubpkg.mod")
         result2 = _get_type_hint([], "another.Klass.method", mod.Klass.method, {})
         assert result2.get("x") is my_type


### PR DESCRIPTION
Ruff 0.15.14 (coming in PR #699) introduces `PLW0717`, which caps `try` clauses at 5 statements. Two tests exceed this.

The fix moves setup code that doesn't need cleanup protection before the `try` — the `try/finally` blocks are purely for cleanup, not exception handling.

Fixes the CI failure on #699.