### PR TITLE
🐛 fix(stubs): resolve type hints for PyO3 native submodules

### DIFF
--- a/src/sphinx_autodoc_typehints/_resolver/_stubs.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_stubs.py
@@ -38,10 +38,20 @@ def _get_stub_context(obj: Any) -> tuple[dict[str, Any], set[str], str]:
     stub_path, owner_module = info
     if (tree := _parse_stub_ast(stub_path)) is None:
         return {}, set(), ""
-    owner_package = getattr(owner_module, "__package__", None) or owner_module.__name__
     ns: dict[str, Any] = dict(vars(owner_module))
-    ns.update(_resolve_stub_imports(tree, owner_package))
+    ns.update(_resolve_stub_imports(tree, _stub_owner_package(owner_module, stub_path)))
     return ns, _extract_type_alias_names(tree), owner_module.__name__
+
+
+def _stub_owner_package(owner_module: types.ModuleType, stub_path: Path) -> str:
+    # Native submodules expose ``__package__ = None``; derive the package from the stub's name
+    # so relative imports inside ``<child>.pyi`` resolve relative to its parent package.
+    if owner_package := getattr(owner_module, "__package__", None):
+        return owner_package
+    owner_name = owner_module.__name__
+    if stub_path.name == "__init__.pyi":
+        return owner_name
+    return owner_name.rpartition(".")[0]
 
 
 def _resolve_stub_imports(tree: ast.Module, owner_package: str = "") -> dict[str, Any]:
@@ -161,7 +171,7 @@ def _find_stub_for_module(module: types.ModuleType) -> Path | None:
     try:
         source_file = inspect.getfile(module)
     except TypeError:
-        return None
+        return _find_native_submodule_stub(module)
     source = Path(source_file)
     if (stub := source.with_name(f"{source.name.split('.')[0]}.pyi")).is_file():
         return stub
@@ -169,6 +179,21 @@ def _find_stub_for_module(module: types.ModuleType) -> Path | None:
         for pkg_dir in module.__path__:
             if (init_stub := Path(pkg_dir) / "__init__.pyi").is_file():
                 return init_stub
+    return None
+
+
+def _find_native_submodule_stub(module: types.ModuleType) -> Path | None:
+    """Locate the sibling ``.pyi`` for a PyO3-style submodule registered via ``PyModule_AddObject``."""
+    name = getattr(module, "__name__", "")
+    parent_name, _, child = name.rpartition(".")
+    if not parent_name or (parent := sys.modules.get(parent_name)) is None:
+        return None
+    for pkg_dir in getattr(parent, "__path__", []) or []:
+        pkg_path = Path(pkg_dir)
+        if (stub := pkg_path / f"{child}.pyi").is_file():
+            return stub
+        if (init_stub := pkg_path / child / "__init__.pyi").is_file():
+            return init_stub
     return None
 
 

--- a/tests/roots/test-pyi-stubs/native_pkg/__init__.py
+++ b/tests/roots/test-pyi-stubs/native_pkg/__init__.py
@@ -1,0 +1,6 @@
+"""PyO3-shaped reproduction package for discussion #698."""
+
+from __future__ import annotations
+
+from . import _native  # noqa: F401
+from . import warc as warc

--- a/tests/roots/test-pyi-stubs/native_pkg/_native.c
+++ b/tests/roots/test-pyi-stubs/native_pkg/_native.c
@@ -1,0 +1,108 @@
+/* Mirrors the PyO3 native-submodule shape from discussion #698:
+ * ``native_pkg.warc`` is built via ``PyModule_New`` and registered in ``sys.modules`` with no
+ * ``__file__`` / ``__spec__`` / ``__path__``.
+ */
+
+#include <Python.h>
+
+static PyObject *parse(PyObject *self, PyObject *args) {
+    (void)self;
+    (void)args;
+    Py_RETURN_NONE;
+}
+
+static PyObject *raw_parse(PyObject *self, PyObject *args) {
+    (void)self;
+    (void)args;
+    Py_RETURN_NONE;
+}
+
+/* ``parse`` uses the PyO3-style Argument Clinic header (recoverable signature);
+ * ``raw_parse`` omits it so we cover the no-signature path. */
+static PyMethodDef warc_methods[] = {
+    {"parse", parse, METH_VARARGS,
+     "parse($module, data)\n--\n\nParse WARC records.\n\n:param data: input bytes"},
+    {"raw_parse", raw_parse, METH_VARARGS,
+     "Parse WARC records.\n\n:param data: input bytes"},
+    {NULL, NULL, 0, NULL}
+};
+
+static PyTypeObject WarcRecordType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "native_pkg.warc.WarcRecord",
+    .tp_doc = "A WARC record (native).",
+    .tp_basicsize = sizeof(PyObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_new = PyType_GenericNew,
+};
+
+static int register_warc_submodule(PyObject *parent) {
+    PyObject *warc = PyModule_New("native_pkg.warc");
+    if (warc == NULL) {
+        return -1;
+    }
+
+    if (PyType_Ready(&WarcRecordType) < 0) {
+        Py_DECREF(warc);
+        return -1;
+    }
+    Py_INCREF(&WarcRecordType);
+    if (PyModule_AddObject(warc, "WarcRecord", (PyObject *)&WarcRecordType) < 0) {
+        Py_DECREF(&WarcRecordType);
+        Py_DECREF(warc);
+        return -1;
+    }
+
+    if (PyModule_AddFunctions(warc, warc_methods) < 0) {
+        Py_DECREF(warc);
+        return -1;
+    }
+
+    Py_INCREF(warc);
+    if (PyModule_AddObject(parent, "warc", warc) < 0) {
+        Py_DECREF(warc);
+        Py_DECREF(warc);
+        return -1;
+    }
+
+    PyObject *sys_modules = PyImport_GetModuleDict();
+    if (sys_modules == NULL) {
+        Py_DECREF(warc);
+        return -1;
+    }
+    if (PyDict_SetItemString(sys_modules, "native_pkg.warc", warc) < 0) {
+        Py_DECREF(warc);
+        return -1;
+    }
+    Py_DECREF(warc);
+    return 0;
+}
+
+static int native_exec(PyObject *m) {
+    return register_warc_submodule(m);
+}
+
+static PyModuleDef_Slot native_slots[] = {
+    {Py_mod_exec, native_exec},
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static struct PyModuleDef native_module = {
+    PyModuleDef_HEAD_INIT,
+    "native_pkg._native",
+    NULL,
+    0,
+    NULL,
+    native_slots,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC PyInit__native(void) {
+    return PyModuleDef_Init(&native_module);
+}

--- a/tests/roots/test-pyi-stubs/native_pkg/warc.pyi
+++ b/tests/roots/test-pyi-stubs/native_pkg/warc.pyi
@@ -1,0 +1,9 @@
+from collections.abc import Iterator
+from typing import Self
+
+class WarcRecord:
+    record_id: str
+    def __new__(cls, record_id: str) -> Self: ...
+
+def parse(data: bytes) -> Iterator[WarcRecord]: ...
+def raw_parse(data: bytes) -> Iterator[WarcRecord]: ...

--- a/tests/test_resolver/test_stubs.py
+++ b/tests/test_resolver/test_stubs.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import ast
+import importlib
+import inspect
 import os
+import shutil
+import subprocess  # noqa: S404
 import sys
+import sysconfig
 import textwrap
 import types
 from collections.abc import Sequence
@@ -21,6 +26,7 @@ from sphinx_autodoc_typehints._resolver._stubs import (
     _extract_func_annotations,
     _extract_type_alias_names,
     _find_ast_node,
+    _find_native_submodule_stub,
     _find_stub_for_module,
     _find_stub_owner,
     _find_stub_path,
@@ -29,9 +35,11 @@ from sphinx_autodoc_typehints._resolver._stubs import (
     _parse_stub_ast,
     _resolve_import_from,
     _resolve_stub_imports,
+    _stub_owner_package,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from io import StringIO
 
     from sphinx.testing.util import SphinxTestApp
@@ -661,3 +669,227 @@ def test_get_stub_context_resolves_relative_imports(tmp_path: Path) -> None:
         for mod_name in [k for k in sys.modules if k.startswith("relpkg")]:
             sys.modules.pop(mod_name, None)
         _STUB_AST_CACHE.clear()
+
+
+@pytest.mark.parametrize(
+    ("owner_name", "package_attr", "stub_name", "expected"),
+    [
+        pytest.param("pkg", "pkg", "__init__.pyi", "pkg", id="package_with_attr"),
+        pytest.param("pkg.warc", None, "warc.pyi", "pkg", id="native_module_no_attr"),
+        pytest.param("pkg.sub", None, "__init__.pyi", "pkg.sub", id="native_subpackage_no_attr"),
+        pytest.param("solo", "", "solo.pyi", "", id="top_level_module"),
+        pytest.param("a.b.c", None, "c.pyi", "a.b", id="deep_module"),
+    ],
+)
+def test_stub_owner_package(owner_name: str, package_attr: str | None, stub_name: str, expected: str) -> None:
+    module = types.ModuleType(owner_name)
+    if package_attr is None:
+        del module.__package__
+    else:
+        module.__package__ = package_attr
+    assert _stub_owner_package(module, Path(stub_name)) == expected
+
+
+@pytest.fixture(scope="module")
+def native_subpkg_layout(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[Path, types.ModuleType, types.ModuleType]]:
+    root = tmp_path_factory.mktemp("native_subpkg")
+    pkg_dir = root / "natpkg_edge"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "warc.pyi").write_text(
+        textwrap.dedent("""\
+            class WarcRecord:
+                record_id: str
+        """)
+    )
+    parent = types.ModuleType("natpkg_edge")
+    parent.__file__ = str(pkg_dir / "__init__.py")
+    parent.__path__ = [str(pkg_dir)]
+    child = types.ModuleType("natpkg_edge.warc")
+    yield pkg_dir, parent, child
+    _STUB_AST_CACHE.clear()
+
+
+def test_find_native_submodule_stub_sibling_pyi(
+    native_subpkg_layout: tuple[Path, types.ModuleType, types.ModuleType],
+) -> None:
+    _, parent, child = native_subpkg_layout
+    with patch.dict(sys.modules, {"natpkg_edge": parent, "natpkg_edge.warc": child}):
+        result = _find_native_submodule_stub(child)
+    assert result is not None
+    assert result.name == "warc.pyi"
+
+
+def test_find_native_submodule_stub_subpackage_init_pyi(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "natpkg_sub"
+    pkg_dir.mkdir()
+    sub_stub_dir = pkg_dir / "sub"
+    sub_stub_dir.mkdir()
+    (sub_stub_dir / "__init__.pyi").write_text("x: int\n")
+    parent = types.ModuleType("natpkg_sub")
+    parent.__path__ = [str(pkg_dir)]
+    child = types.ModuleType("natpkg_sub.sub")
+    with patch.dict(sys.modules, {"natpkg_sub": parent, "natpkg_sub.sub": child}):
+        result = _find_native_submodule_stub(child)
+    assert result is not None
+    assert result.name == "__init__.pyi"
+    assert result.parent.name == "sub"
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        pytest.param("top_level_native", id="no_dot_in_name"),
+        pytest.param("absent.child", id="parent_missing_in_sys_modules"),
+    ],
+)
+def test_find_native_submodule_stub_returns_none_without_parent(module_name: str) -> None:
+    sys.modules.pop(module_name.partition(".")[0], None)
+    assert _find_native_submodule_stub(types.ModuleType(module_name)) is None
+
+
+def test_find_native_submodule_stub_parent_without_path(tmp_path: Path) -> None:
+    parent = types.ModuleType("flat_native")
+    parent.__file__ = str(tmp_path / "flat.py")
+    child = types.ModuleType("flat_native.child")
+    with patch.dict(sys.modules, {"flat_native": parent, "flat_native.child": child}):
+        assert _find_native_submodule_stub(child) is None
+
+
+def test_find_native_submodule_stub_no_matching_stub(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "natpkg_empty"
+    pkg_dir.mkdir()
+    parent = types.ModuleType("natpkg_empty")
+    parent.__path__ = [str(pkg_dir)]
+    child = types.ModuleType("natpkg_empty.missing")
+    with patch.dict(sys.modules, {"natpkg_empty": parent, "natpkg_empty.missing": child}):
+        assert _find_native_submodule_stub(child) is None
+
+
+def test_find_stub_for_module_uses_native_submodule_fallback(
+    native_subpkg_layout: tuple[Path, types.ModuleType, types.ModuleType],
+) -> None:
+    _, parent, child = native_subpkg_layout
+    with patch.dict(sys.modules, {"natpkg_edge": parent, "natpkg_edge.warc": child}):
+        result = _find_stub_for_module(child)
+    assert result is not None
+    assert result.name == "warc.pyi"
+
+
+@pytest.fixture(scope="module")
+def native_pkg(tmp_path_factory: pytest.TempPathFactory) -> Iterator[types.ModuleType]:
+    """Compile and import the PyO3-shaped reproduction extension from discussion #698."""
+    if not sysconfig.get_config_var("LDSHARED"):  # pragma: no cover
+        pytest.skip("no C compiler available")
+    build_dir = tmp_path_factory.mktemp("native_pkg_root")
+    pkg_dir = build_dir / "native_pkg"
+    pkg_dir.mkdir()
+    src_pkg = STUB_ROOT / "native_pkg"
+    for name in ("__init__.py", "warc.pyi"):
+        shutil.copyfile(src_pkg / name, pkg_dir / name)
+
+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    so_file = pkg_dir / f"_native{ext_suffix}"
+    include_dir = sysconfig.get_path("include")
+    ldshared = sysconfig.get_config_var("LDSHARED") or f"{sysconfig.get_config_var('CC') or 'cc'} -shared"
+    cflags = sysconfig.get_config_var("CFLAGS") or ""
+    try:
+        subprocess.check_call(
+            [*ldshared.split(), f"-I{include_dir}", *cflags.split(), "-o", str(so_file), str(src_pkg / "_native.c")],
+            cwd=str(pkg_dir),
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):  # pragma: no cover
+        pytest.skip("C extension compilation failed")
+
+    sys.path.insert(0, str(build_dir))
+    try:
+        mod = importlib.import_module("native_pkg")
+    finally:
+        sys.path.pop(0)
+    yield mod
+    for name in [k for k in sys.modules if k == "native_pkg" or k.startswith("native_pkg.")]:
+        sys.modules.pop(name, None)
+    _STUB_AST_CACHE.clear()
+
+
+def test_native_submodule_has_no_file(native_pkg: types.ModuleType) -> None:
+    warc = native_pkg.warc
+    assert not hasattr(warc, "__file__")
+    assert not hasattr(warc, "__path__")
+    assert warc.__name__ == "native_pkg.warc"
+
+
+def test_find_stub_owner_resolves_native_submodule_stub(native_pkg: types.ModuleType) -> None:
+    info = _find_stub_owner(native_pkg.warc.WarcRecord)
+    assert info is not None
+    stub_path, owner = info
+    assert stub_path.name == "warc.pyi"
+    assert owner is native_pkg.warc
+
+
+def test_backfill_from_stub_for_native_submodule(native_pkg: types.ModuleType) -> None:
+    parse_annotations = _backfill_from_stub(native_pkg.warc.parse)
+    assert parse_annotations == {"data": "bytes", "return": "Iterator[WarcRecord]"}
+
+
+def test_get_stub_context_resolves_relative_imports_for_native_submodule(native_pkg: types.ModuleType) -> None:
+    ns, _names, owner = _get_stub_context(native_pkg.warc.parse)
+    assert owner == "native_pkg.warc"
+    assert ns["Iterator"].__module__ == "collections.abc"
+
+
+def test_native_function_signature_from_clinic_docstring(native_pkg: types.ModuleType) -> None:
+    assert inspect.signature(native_pkg.warc.parse).parameters
+    with pytest.raises(ValueError, match="no signature found"):
+        inspect.signature(native_pkg.warc.raw_parse)
+
+
+@pytest.mark.usefixtures("native_pkg")
+@pytest.mark.sphinx("text", testroot="pyi-stubs")
+def test_sphinx_build_resolves_param_and_return_for_native_submodule(
+    app: SphinxTestApp, status: StringIO, warning: StringIO
+) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        textwrap.dedent("""\
+            .. autofunction:: native_pkg.warc.parse
+        """)
+    )
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    assert "bytes" in result
+    assert "Iterator" in result
+    assert "WarcRecord" in result
+    warn_text = warning.getvalue()
+    assert "native_pkg" not in warn_text or "forward reference" not in warn_text
+
+
+@pytest.mark.usefixtures("native_pkg")
+@pytest.mark.sphinx("text", testroot="pyi-stubs")
+def test_sphinx_build_falls_back_to_return_only_without_signature(app: SphinxTestApp, status: StringIO) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        textwrap.dedent("""\
+            .. autofunction:: native_pkg.warc.raw_parse
+        """)
+    )
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    assert "Iterator" in result
+    assert "WarcRecord" in result
+
+
+@pytest.mark.usefixtures("native_pkg")
+@pytest.mark.sphinx("text", testroot="pyi-stubs")
+def test_sphinx_build_documents_native_class(app: SphinxTestApp, status: StringIO) -> None:
+    (Path(app.srcdir) / "index.rst").write_text(
+        textwrap.dedent("""\
+            .. autoclass:: native_pkg.warc.WarcRecord
+        """)
+    )
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    assert "WarcRecord" in result


### PR DESCRIPTION
PyO3, pybind11, and nanobind register submodules at runtime via `PyModule_AddObject`, so the resulting module objects have no `__file__`, no `__spec__`, no `__path__`, and `__package__` is `None`. The existing stub resolver bailed out the moment `inspect.getfile` raised `TypeError`, and walked up to the parent's `__init__.pyi` — which in typical layouts (`fastwarc`, cbor2-style) only re-exports symbols and carries none of the actual annotations. The user case in discussion #698 ends up with no parameter or return types in the rendered docs unless they keep the `:type:` lines they were trying to remove.

The fix walks the parent package's `__path__` to find a sibling `<child>.pyi` (or `<child>/__init__.pyi`), matching the canonical PEP 561 layout. It avoids touching the import system, so we don't have to mirror Sphinx 8.2's meta-path-finder approach. Relative imports inside such stubs (`from .stream_io import …`) get an extra fix in `_get_stub_context`: since `__package__` is `None`, the prior `__package__ or __name__` fallback resolved relatives against the submodule itself. Deriving the owning package from the stub filename keeps both regular packages and native submodules correct.

A real C extension under `tests/roots/test-pyi-stubs/native_pkg/` reproduces the PyO3 shape end-to-end (`PyModule_New` + `PyDict_SetItemString`) and covers both signature paths — Argument Clinic headers (signature recoverable, PyO3 default) and bare `METH_VARARGS` (no signature). Verified locally against `fastwarc==1.0.1`: all parameter and return types now flow into the rendered docs, including cross-submodule references like `WarcWriter | BinaryIO | _GenericWriter`.

Fixes #698