### PR TITLE
🐛 fix(annotations): avoid NameError for TYPE_CHECKING-only annotations on 3.14

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import sys
 import types
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -65,7 +66,12 @@ def process_signature(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0917
 
     original_obj = obj
     obj = getattr(obj, "__init__", getattr(obj, "__new__", None)) if inspect.isclass(obj) else obj
-    if not getattr(obj, "__annotations__", None):
+    # In Python 3.14+, accessing __annotations__ evaluates lazy annotations (PEP 649) and raises
+    # NameError for TYPE_CHECKING-only names. __annotate__ is safe: it is None iff no annotations.
+    if sys.version_info >= (3, 14):
+        if not getattr(obj, "__annotate__", None):
+            return None
+    elif not getattr(obj, "__annotations__", None):
         return None
 
     try:

--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import inspect
 import re
-import sys
 import types
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -66,12 +65,15 @@ def process_signature(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0917
 
     original_obj = obj
     obj = getattr(obj, "__init__", getattr(obj, "__new__", None)) if inspect.isclass(obj) else obj
-    # In Python 3.14+, accessing __annotations__ evaluates lazy annotations (PEP 649) and raises
-    # NameError for TYPE_CHECKING-only names. __annotate__ is safe: it is None iff no annotations.
-    if sys.version_info >= (3, 14):
-        if not getattr(obj, "__annotate__", None):
-            return None
-    elif not getattr(obj, "__annotations__", None):
+    try:
+        has_annotations = getattr(obj, "__annotations__", None)
+    except NameError:
+        # PEP 649 (Python 3.14+): accessing __annotations__ may raise NameError when annotations
+        # reference TYPE_CHECKING-only names. Setting __annotations__ clears __annotate__, so we
+        # only reach here when annotations come from the original function definition. If __annotate__
+        # is callable, the function has annotations; proceed so sphinx_signature can use FORWARDREF.
+        has_annotations = getattr(obj, "__annotate__", None)
+    if not has_annotations:
         return None
 
     try:

--- a/src/sphinx_autodoc_typehints/_resolver/_util.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_util.py
@@ -28,20 +28,15 @@ def collect_documented_type_aliases(
     obj: Any, module_prefix: str, env: BuildEnvironment
 ) -> tuple[dict[str, MyTypeAliasForwardRef], dict[int, MyTypeAliasForwardRef]]:
     py_objects = env.get_domain("py").objects  # ty: ignore[unresolved-attribute]
-    deferred: dict[str, MyTypeAliasForwardRef] = {}
+    deferred = _collect_module_type_aliases(module_prefix, py_objects)
     eager: dict[int, MyTypeAliasForwardRef] = {}
 
-    prefix_dot = f"{module_prefix}."
-    for fqn, obj_info in py_objects.items():
-        if obj_info.objtype != "type":
-            continue
-        if fqn.startswith(prefix_dot) or fqn == module_prefix:
-            short_name = fqn.rsplit(".", 1)[-1]
-            ref = MyTypeAliasForwardRef(short_name)
-            ref.crossref = True
-            deferred[short_name] = ref
-
-    raw_annotations = getattr(obj, "__annotations__", {})
+    # In Python 3.14+, accessing __annotations__ evaluates lazy annotations (PEP 649) and
+    # may raise NameError for TYPE_CHECKING-only names before imports are resolved.
+    try:
+        raw_annotations = getattr(obj, "__annotations__", {})
+    except NameError:
+        return deferred, eager
     if not raw_annotations:
         return deferred, eager
 
@@ -64,6 +59,18 @@ def collect_documented_type_aliases(
                     eager[id(annotation)] = ref
 
     return deferred, eager
+
+
+def _collect_module_type_aliases(module_prefix: str, py_objects: dict[str, Any]) -> dict[str, MyTypeAliasForwardRef]:
+    prefix_dot = f"{module_prefix}."
+    result: dict[str, MyTypeAliasForwardRef] = {}
+    for fqn, obj_info in py_objects.items():
+        if obj_info.objtype == "type" and (fqn.startswith(prefix_dot) or fqn == module_prefix):
+            short_name = fqn.rsplit(".", 1)[-1]
+            ref = MyTypeAliasForwardRef(short_name)
+            ref.crossref = True
+            result[short_name] = ref
+    return result
 
 
 def _is_documented_type(name: str, module_prefix: str, py_objects: dict[str, Any]) -> bool:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -298,6 +298,22 @@ def test_process_docstring_strips_complex_inline_param_type() -> None:
     assert "int" in type_lines[0]
 
 
+def test_process_signature_annotations_name_error() -> None:
+    """PEP 649 lazy annotations raising NameError must not propagate from process_signature."""
+
+    class _Func:
+        @property
+        def __annotations__(self) -> dict[str, object]:  # noqa: PLW3201
+            msg = "Callable"
+            raise NameError(msg)
+
+        def __call__(self) -> None: ...
+
+    app = make_sig_app()
+    result = process_signature(app, "function", "test.func", _Func(), MagicMock(), "", "")
+    assert result is None
+
+
 def test_setup_returns_version() -> None:
     """setup() returns metadata dict with version from __version__."""
     app = create_autospec(Sphinx)

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -352,3 +352,43 @@ def test_pep695_external_type_alias(
     result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
     assert '"ExtAlias"' in result
     assert '"str" | "int"' not in result
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="PEP 649 lazy annotation evaluation is Python 3.14+")
+@pytest.mark.sphinx("text", testroot="integration")
+def test_pep695_type_checking_only_annotation(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for #703: PEP 695 generic functions with TYPE_CHECKING-only annotations
+    must not raise NameError during Sphinx processing."""
+    mod = types.ModuleType("mod_703")
+    mod.__file__ = __file__
+    exec(  # noqa: S102
+        dedent("""\
+        import functools
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from collections.abc import Callable
+
+        def my_customizable_decorator[**P, R]() -> Callable[[Callable[P, R]], Callable[P, R]]:
+            \"\"\"Return a decorator that wraps functions.\"\"\"
+            def decorator[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+                @functools.wraps(func)
+                def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                    return func(*args, **kwargs)
+                return wrapper
+            return decorator
+        """),
+        mod.__dict__,
+    )
+    (Path(app.srcdir) / "index.rst").write_text(".. autofunction:: mod_703.my_customizable_decorator")
+    monkeypatch.setitem(sys.modules, "mod_703", mod)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    # The fix prevents process_signature from throwing — a forward_reference warning
+    # for unresolvable TYPE_CHECKING imports in exec'd modules is acceptable.
+    assert "threw an exception" not in warning.getvalue()

--- a/tests/test_resolver/test_util.py
+++ b/tests/test_resolver/test_util.py
@@ -88,3 +88,18 @@ def test_collect_documented_type_aliases_ignores_unqualified_names() -> None:
     deferred, eager = collect_documented_type_aliases(obj, "cbor2", env)
     assert "EncoderHook" not in deferred
     assert eager == {}
+
+
+def test_collect_documented_type_aliases_annotations_name_error() -> None:
+    """PEP 649 lazy annotations raising NameError must not propagate."""
+
+    class _AnnotationsRaiser:
+        @property
+        def __annotations__(self) -> dict[str, object]:  # noqa: PLW3201
+            msg = "Callable"
+            raise NameError(msg)
+
+    env = _make_env_with_types(["mymod.MyType"])
+    deferred, eager = collect_documented_type_aliases(_AnnotationsRaiser(), "mymod", env)
+    assert "MyType" in deferred
+    assert eager == {}


### PR DESCRIPTION
On Python 3.14, PEP 649 changes `__annotations__` from a plain dict into a
lazy descriptor that calls `__annotate__(Format.VALUE)` on first access. When
a function's annotations reference names imported only under `TYPE_CHECKING`
(e.g. `Callable` from `collections.abc`), that evaluation raises `NameError`.
Because `getattr(obj, "__annotations__", default)` only catches `AttributeError`,
the `NameError` propagated unhandled through `process_signature` and
`collect_documented_type_aliases`, producing the warning:

> `Handler <function process_signature> for event 'autodoc-process-signature' threw an exception (exception: name 'Callable' is not defined)`

This is particularly visible with PEP 695 generic functions (`def foo[**P, R]()`)
whose annotations are never evaluated at definition time, making it easy to
miss the missing runtime import. 🐍

In `process_signature` the fix switches to checking `__annotate__` as the
annotation-presence sentinel on Python 3.14+. CPython sets `__annotate__` to
`None` when a function has no annotations and to a callable otherwise — checking
its presence never triggers evaluation. In `collect_documented_type_aliases`
the annotation access is wrapped in a `try/except NameError` so that objects
whose annotations cannot yet be evaluated are skipped gracefully; their type
hints are still resolved later via the normal `get_type_hints` path after
guarded imports are injected.

Closes #703