### PR TITLE
process_signature: don't skip the first arg on bound instance methods

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -118,7 +118,7 @@ def process_signature(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0917
             if method_name.startswith("__") and not method_name.endswith("__"):
                 method_name = f"_{obj.__qualname__.split('.')[-2]}{method_name}"
             method_object = outer.__dict__.get(method_name, obj) if outer else obj
-            if not isinstance(method_object, classmethod | staticmethod):
+            if not isinstance(method_object, classmethod | staticmethod) and not inspect.ismethod(obj):
                 start = 1
 
     sph_signature = sph_signature.replace(parameters=parameters[start:])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -48,6 +48,17 @@ def test_process_signature_private_name_mangling() -> None:
     assert "self" not in sig_str
 
 
+def test_process_signature_class_instance() -> None:
+    """Line 121: bound instance methods should not have their first argument removed."""
+    instance = _ClassWithPrivate()
+    method = _ClassWithPrivate.__dict__["_ClassWithPrivate__secret"].__get__(instance)
+    app = make_sig_app()
+    result = process_signature(app, "method", "test_init._ClassWithPrivate.__secret", method, MagicMock(), "", "")
+    assert result is not None
+    sig_str, _ = result
+    assert sig_str == "(x)"
+
+
 def test_process_docstring_sphinx_signature_raises_value_error() -> None:
     """Lines 157-158: sphinx_signature raising ValueError sets signature to None."""
 


### PR DESCRIPTION
Methods bound on class instances do not have `self` as part of their signature, so skipping the first argument is wrong.