### PR TITLE
🐛 fix(docstring): keep types on params with a trailing underscore

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -325,9 +325,9 @@ def _inject_arg_signature(  # noqa: PLR0913, PLR0917
     doc_description = _extract_doc_description(annotation) if annotation is not None else None
 
     if arg_name.endswith("_"):
-        arg_name = f"{arg_name[:-1]}\\_"
-
-    insert_index = fmt.find_param(lines, arg_name)
+        arg_name, insert_index = _find_trailing_underscore_param(lines, arg_name, fmt)
+    else:
+        insert_index = fmt.find_param(lines, arg_name)
 
     if (
         insert_index is not None
@@ -374,6 +374,21 @@ def _inject_arg_signature(  # noqa: PLR0913, PLR0917
         )
 
     lines.insert(insert_index, type_annotation)
+
+
+def _find_trailing_underscore_param(lines: list[str], arg_name: str, fmt: Any) -> tuple[str, int | None]:
+    escaped_name = f"{arg_name[:-1]}\\_"
+    if (insert_index := fmt.find_param(lines, escaped_name)) is not None:
+        return escaped_name, insert_index
+    if (insert_index := fmt.find_param(lines, arg_name)) is None:
+        return escaped_name, None
+    # napoleon only escapes the trailing underscore when strip_signature_backslash is on, and docutils
+    # swallows an unescaped one as reference markup — see issue #708
+    rewritten = lines[insert_index].replace(f" {arg_name}:", f" {escaped_name}:", 1)
+    if rewritten == lines[insert_index]:
+        return arg_name, insert_index
+    lines[insert_index] = rewritten
+    return escaped_name, insert_index
 
 
 def _remove_preexisting_type(lines: list[str], preexisting_line: str) -> int:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import inspect
+from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
 
+import pytest
 from conftest import make_docstring_app, make_sig_app
 from sphinx.application import Sphinx
 from sphinx.config import Config
@@ -307,6 +309,52 @@ def test_process_docstring_strips_complex_inline_param_type() -> None:
     type_lines = [line for line in lines if line.startswith(":type fp:")]
     assert len(type_lines) == 1
     assert "int" in type_lines[0]
+
+
+def _trailing_underscore_func(lambda_: float) -> None: ...
+
+
+def _trailing_underscore_starred_func(*args_: float) -> None: ...
+
+
+def _trailing_underscore_undocumented_func(x_: float) -> None: ...
+
+
+@pytest.mark.parametrize(
+    ("func", "lines", "expected_param_line", "expected_type_name"),
+    [
+        pytest.param(
+            _trailing_underscore_func,
+            [":param lambda_: description"],
+            ":param lambda\\_: description",
+            "lambda\\_",
+            id="unescaped-line-rewritten",
+        ),
+        pytest.param(
+            _trailing_underscore_starred_func,
+            [":param \\*args_: description"],
+            ":param \\*args_: description",
+            "args_",
+            id="starred-line-kept",
+        ),
+        pytest.param(
+            _trailing_underscore_undocumented_func,
+            [],
+            ":param x\\_:",
+            "x\\_",
+            id="undocumented-escaped",
+        ),
+    ],
+)
+def test_process_docstring_trailing_underscore_param(
+    func: Any, lines: list[str], expected_param_line: str, expected_type_name: str
+) -> None:
+    """napoleon emits ``:param lambda_:`` unescaped by default; the param line must be rewritten to
+    the escaped form and the type attached, except for forms that cannot be rewritten (issue #708)."""
+    app = make_docstring_app(typehints_document_rtype=False, always_document_param_types=True)
+    process_docstring(app, "function", "test.func", func, None, lines)
+    assert expected_param_line in lines
+    assert any(line.startswith(":type ") and expected_type_name in line and "float" in line for line in lines)
 
 
 def test_process_signature_annotations_name_error() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -306,6 +306,61 @@ def function(x: bool, y: int, z_: Optional[str] = None) -> str:
 
 @expected(
     """\
+mod.function_with_trailing_underscore_numpy(a, lambda_=None)
+
+   Do nothing.
+
+   Parameters:
+      * **a** ("int") -- Description for a.
+
+      * **lambda_** ("float" | "None", default: "None") -- Description
+        for lambda.
+
+   Return type:
+      "None"
+""",
+    typehints_defaults="comma",
+)
+def function_with_trailing_underscore_numpy(a: int, lambda_: float | None = None) -> None:
+    """Do nothing.
+
+    Parameters
+    ----------
+    a
+        Description for a.
+    lambda_
+        Description for lambda.
+    """
+
+
+@expected(
+    """\
+mod.function_with_trailing_underscore_google(a, lambda_=None)
+
+   Do nothing.
+
+   Parameters:
+      * **a** ("int") -- Description for a.
+
+      * **lambda_** ("float" | "None", default: "None") -- Description
+        for lambda.
+
+   Return type:
+      "None"
+""",
+    typehints_defaults="comma",
+)
+def function_with_trailing_underscore_google(a: int, lambda_: float | None = None) -> None:
+    """Do nothing.
+
+    Args:
+        a: Description for a.
+        lambda_: Description for lambda.
+    """
+
+
+@expected(
+    """\
 mod.function_with_starred_documentation_param_names(*args, **kwargs)
 
    Function docstring.


### PR DESCRIPTION
Parameters following the keyword-clash naming convention (`lambda_`, `type_`) rendered without their type and default when documented through napoleon, and the trailing underscore disappeared from the output. The lookup in `_inject_arg_signature` escapes the underscore unconditionally, while napoleon only emits the escaped `:param lambda\_:` form when `strip_signature_backslash` is enabled, which is off by default. The escaped lookup missed the unescaped line, skipping the `:type` injection, and docutils then parsed the bare `lambda_` as reference markup and dropped the underscore.

The lookup now tries the escaped form first, preserving hand-written RST docstrings that escape the underscore themselves (the #56 behavior), and falls back to the unescaped name. 🔁 A fallback match rewrites the `:param` line to the escaped form so the underscore survives rendering and the `:type` line pairs with it. Forms that resist a safe rewrite, such as starred params, keep the unescaped name so the type still attaches. Raw numpydoc docstrings gain the same repair for free because the numpydoc handler converts to Sphinx fields before delegating its lookup.

`lambda_` now renders as `lambda_ (float | None, default: None) – Description for lambda.` for both numpy and google napoleon styles.

Fixes #708.