### PR TITLE
🐛 fix(annotations): render recursive type aliases

### DIFF
--- a/src/sphinx_autodoc_typehints/_annotations.py
+++ b/src/sphinx_autodoc_typehints/_annotations.py
@@ -21,7 +21,7 @@ from sphinx.util import rst
 from sphinx.util.inspect import TypeAliasForwardRef
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Generator
 
     from sphinx.config import Config
 
@@ -74,8 +74,59 @@ class MyTypeAliasForwardRef(TypeAliasForwardRef):
         return Union[self, value]  # noqa: UP007
 
 
-def format_annotation(annotation: Any, config: Config, *, short_literals: bool = False) -> str:  # noqa: C901, PLR0911, PLR0912, PLR0915, PLR0914
-    """Format the annotation."""
+def format_annotation(annotation: Any, config: Config, *, short_literals: bool = False) -> str:
+    """
+    Format the annotation into reStructuredText cross-reference markup.
+
+    The annotation is a tree (``dict[str, list[int]]`` nests three levels), so formatting it is a
+    post-order walk. The walk is driven iteratively with an explicit stack rather than by recursion:
+    a PEP 695 type alias may reference itself (``type T = int | list[T]``), which is a fully
+    supported recursive type but would expand forever and exhaust the interpreter recursion limit if
+    walked naively. Each frame on the stack is one suspended ``_format_node`` generator; the generator
+    yields the child annotations it needs formatted and is resumed with their rendered strings.
+    ``active`` holds the aliases currently being expanded along the path from the root, so when an
+    alias references itself it is rendered as a cross-reference to its own name -- the natural
+    representation of a recursive type -- instead of being expanded again.
+    """
+    fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
+    cycle_prefix = "" if fully_qualified else "~"
+
+    stack = [(_format_node(annotation, config, short_literals=short_literals), annotation)]
+    active = {id(annotation)} if isinstance(annotation, TypeAliasType) else set()
+    rendered: str | None = None
+    while True:
+        gen, node = stack[-1]
+        try:
+            child = next(gen) if rendered is None else gen.send(rendered)
+        except StopIteration as done:
+            stack.pop()
+            if isinstance(node, TypeAliasType):
+                active.discard(id(node))
+            rendered = done.value
+            if not stack:
+                return rendered
+            continue
+        if isinstance(child, TypeAliasType) and id(child) in active:
+            rendered = f":py:type:`{cycle_prefix}{child.__name__}`"
+            continue
+        stack.append((_format_node(child, config, short_literals=short_literals), child))
+        if isinstance(child, TypeAliasType):
+            active.add(id(child))
+        rendered = None
+
+
+def _format_node(  # noqa: C901, PLR0911, PLR0912, PLR0915, PLR0914
+    annotation: Any,
+    config: Config,
+    *,
+    short_literals: bool,
+) -> Generator[Any, str, str]:
+    """
+    Format a single annotation node, delegating nested annotations to :func:`format_annotation`.
+
+    Every nested annotation is ``yield``-ed and the driver sends back its formatted string, so the
+    recursion lives in the driver's explicit stack rather than on the Python call stack.
+    """
     typehints_formatter: Callable[..., str] | None = getattr(config, "typehints_formatter", None)
     if typehints_formatter is not None:
         formatted = typehints_formatter(annotation, config)
@@ -90,7 +141,14 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
         return ":py:data:`...<Ellipsis>`"
 
     if isinstance(annotation, tuple):
-        return _format_internal_tuple(annotation, config)
+        parts = []
+        for item in annotation:
+            parts.append((yield item))  # noqa: PERF401  # yield is illegal inside a comprehension
+        if not parts:
+            return "()"
+        if len(parts) == 1:
+            return f"({parts[0]}, )"
+        return f"({', '.join(parts)})"
 
     if isinstance(annotation, TypeAliasForwardRef):
         fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
@@ -106,7 +164,7 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
         return annotation.name
 
     if isinstance(annotation, TypeAliasType):
-        fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
+        fully_qualified = getattr(config, "typehints_fully_qualified", False)
         prefix = "" if fully_qualified else "~"
         if (env := getattr(config, "_typehints_env", None)) is not None:
             py_domain = env.get_domain("py")
@@ -126,7 +184,7 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
             if canonical and canonical.split(".")[0] != current_top:
                 full_name = _fixup_module_name(config, canonical.rpartition(".")[0]) + "." + annotation.__name__
                 return f":py:obj:`{prefix}{full_name}`"
-        return format_annotation(annotation.__value__, config, short_literals=short_literals)
+        return (yield annotation.__value__)
 
     try:
         module = get_annotation_module(annotation)
@@ -140,7 +198,7 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
     if (mapping := getattr(config, "_intersphinx_type_mapping", None)) and (mapped := mapping.get(internal_path)):
         module, _, class_name = mapped.rpartition(".")
     full_name = f"{module}.{class_name}" if module != "builtins" else class_name
-    fully_qualified: bool = getattr(config, "typehints_fully_qualified", False)
+    fully_qualified = getattr(config, "typehints_fully_qualified", False)
     prefix = "" if fully_qualified or full_name == class_name else "~"
     role = "data" if (module, class_name) in _PYDATA_ANNOTATIONS else "class"
     args_format = "\\[{}]"
@@ -160,15 +218,16 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
         newtype_name = annotation.__name__
         newtype_qualified = f"{newtype_module}.{newtype_name}" if newtype_module else newtype_name
         newtype_prefix = "" if fully_qualified or not newtype_module else "~"
-        supertype = format_annotation(annotation.__supertype__, config, short_literals=short_literals)
+        supertype = yield annotation.__supertype__
         return f":py:class:`{newtype_prefix}{newtype_qualified}` ({supertype})"
     if full_name == "typing.Annotated":
-        return format_annotation(annotation.__origin__, config, short_literals=short_literals)
+        return (yield annotation.__origin__)
     if full_name in {"typing.TypeVar", "typing.ParamSpec"}:
         params = {k: getattr(annotation, f"__{k}__") for k in ("bound", "covariant", "contravariant")}
         params = {k: v for k, v in params.items() if v}
         if "bound" in params:
-            params["bound"] = f" {format_annotation(params['bound'], config, short_literals=short_literals)}"
+            bound = yield params["bound"]
+            params["bound"] = f" {bound}"
         args_format = f"\\(``{annotation.__name__}``{', {}' if args else ''}"
         if params:
             args_format += "".join(f", {k}={v}" for k, v in params.items())
@@ -189,7 +248,9 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
                 args_format = f"\\[:py:data:`{prefix}typing.Union`\\[{{}}]]"
                 args = tuple(x for x in args if x is not type(None))
     elif full_name in {"typing.Callable", "collections.abc.Callable"} and args and args[0] is not ...:
-        fmt = [format_annotation(arg, config, short_literals=short_literals) for arg in args]
+        fmt = []
+        for arg in args:
+            fmt.append((yield arg))  # noqa: PERF401  # yield is illegal inside a comprehension
         formatted_args = f"\\[\\[{', '.join(fmt[:-1])}], {fmt[-1]}]"
     elif full_name == "typing.Literal":
         literal_parts = [_format_literal_arg(arg, config) for arg in args]
@@ -199,14 +260,20 @@ def format_annotation(annotation: Any, config: Config, *, short_literals: bool =
     elif is_bars_union:
         if not args:
             return f":py:{'class' if sys.version_info >= (3, 14) else 'data'}:`{prefix}typing.Union`"
-        return " | ".join([format_annotation(arg, config, short_literals=short_literals) for arg in args])
+        union_parts = []
+        for arg in args:
+            union_parts.append((yield arg))  # noqa: PERF401  # yield is illegal inside a comprehension
+        return " | ".join(union_parts)
 
     if args and not formatted_args:
-        fmt = [format_annotation(arg, config, short_literals=short_literals) for arg in args]
+        fmt = []
+        for arg in args:
+            fmt.append((yield arg))
         formatted_args = args_format.format(", ".join(fmt))
 
     escape = "\\ " if formatted_args else ""
-    return f":py:{role}:`{prefix}{full_name}`{escape}{formatted_args}"
+    # B901: returning a value from a generator is intentional here — the driver reads it via StopIteration
+    return f":py:{role}:`{prefix}{full_name}`{escape}{formatted_args}"  # noqa: B901
 
 
 def get_annotation_module(annotation: Any) -> str:
@@ -275,15 +342,6 @@ def get_annotation_args(annotation: Any, module: str, class_name: str) -> tuple[
         return annotation.__parameters__
     result = getattr(annotation, "__args__", ())
     return () if len(result) == 1 and result[0] == () else result  # type: ignore[misc]
-
-
-def _format_internal_tuple(t: tuple[Any, ...], config: Config, *, short_literals: bool = False) -> str:
-    fmt = [format_annotation(a, config, short_literals=short_literals) for a in t]
-    if len(fmt) == 0:
-        return "()"
-    if len(fmt) == 1:
-        return f"({fmt[0]}, )"
-    return f"({', '.join(fmt)})"
 
 
 def _fixup_module_name(config: Config, module: str) -> str:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -648,3 +648,19 @@ def test_format_annotation_type_alias_found_in_py_domain() -> None:
     config._typehints_env = env  # noqa: SLF001
     annotation = TypeAliasForwardRef("SomeAlias")
     assert format_annotation(annotation, config) == ":py:type:`~mymod.SomeAlias`"
+
+
+def test_format_annotation_recursive_type_alias() -> None:
+    """A self-referential PEP 695 alias renders as a cross-reference to itself, not forever (#720)."""
+    namespace: dict[str, Any] = {}
+    exec("type RecType = int | list[RecType]", namespace)  # noqa: S102
+    result = format_annotation(namespace["RecType"], create_autospec(Config))
+    assert result == ":py:class:`int` | :py:class:`list`\\ \\[:py:type:`~RecType`]"
+
+
+def test_format_annotation_mutually_recursive_type_alias() -> None:
+    """An indirect cycle between PEP 695 aliases resolves to a self cross-reference too (#720)."""
+    namespace: dict[str, Any] = {}
+    exec("type A = int | list[B]\ntype B = str | list[A]", namespace)  # noqa: S102
+    result = format_annotation(namespace["A"], create_autospec(Config))
+    assert result == ":py:class:`int` | :py:class:`list`\\ \\[:py:class:`str` | :py:class:`list`\\ \\[:py:type:`~A`]]"

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -498,6 +498,43 @@ def test_documented_type_alias_crossref(
 
 
 @pytest.mark.sphinx("text", testroot="integration")
+def test_recursive_type_alias_does_not_recurse_forever(
+    app: SphinxTestApp,
+    status: StringIO,
+    warning: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A self-referential PEP 695 alias builds cleanly and renders as a self cross-reference (#720)."""
+    mod = types.ModuleType("mod_720")
+    mod.__file__ = __file__
+    exec(  # noqa: S102
+        dedent("""\
+        from __future__ import annotations
+
+        type RecType = int | list[RecType]
+        \"\"\"A recursive type alias.\"\"\"
+
+        def some_func(some_param: RecType) -> None:
+            \"\"\"Describe.
+
+            :param some_param: some description
+            \"\"\"
+            ...
+        """),
+        mod.__dict__,
+    )
+    (Path(app.srcdir) / "index.rst").write_text(".. autofunction:: mod_720.some_func")
+    monkeypatch.setitem(sys.modules, "mod_720", mod)
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    value = warning.getvalue().strip()
+    assert not value or "Inline strong start-string without end-string" in value
+
+    result = normalize_sphinx_text((Path(app.srcdir) / "_build/text/index.txt").read_text())
+    assert '"RecType"' in result
+
+
+@pytest.mark.sphinx("text", testroot="integration")
 def test_eager_annotations(
     app: SphinxTestApp,
     status: StringIO,


### PR DESCRIPTION
Documenting a module that defines a self-referential PEP 695 type alias such as `type RecType = int | list[RecType]` aborted the Sphinx build with `maximum recursion depth exceeded`. 🐛 `format_annotation` expanded the alias value to render it, and because that value contains the alias again (nested inside `list[...]`), the expansion never terminated. This is reported in #720.

Recursive type aliases are a valid, supported construct, so the formatter now treats them as such instead of failing. The annotation tree is walked iteratively over an explicit stack of suspended generators rather than through the Python call stack, which removes the dependence on the interpreter recursion limit. The set of aliases currently being expanded along the path from the root is tracked, and when an alias references itself it renders as a `:py:type:` cross-reference to its own name, the natural representation of a recursive type, rather than expanding a second time. ✨ Mutually recursive aliases (`A` referring to `B` referring to `A`) resolve the same way.

`type RecType = int | list[RecType]` now renders as `int | list[RecType]` with the inner `RecType` linking back to the alias, and builds complete without warnings.

Closes #720