### PR TITLE
🐛 fix(overloads): keep summary above overloads

### DIFF
--- a/src/sphinx_autodoc_typehints/__init__.py
+++ b/src/sphinx_autodoc_typehints/__init__.py
@@ -236,9 +236,16 @@ def _inject_overload_signatures(
         return False
     if (overloads := _resolve_overloads(obj)) is None:
         return False
-    for line in reversed(_format_overload_lines(overloads, app)):
-        lines.insert(0, line)
+    idx = _summary_end(lines)
+    lines[idx:idx] = ["", *_format_overload_lines(overloads, app)]
     return True
+
+
+def _summary_end(lines: list[str]) -> int:
+    """Index past the summary paragraph so overloads land below it and autosummary still reads it (#730)."""
+    if (start := next((i for i, line in enumerate(lines) if line.strip()), None)) is None:
+        return len(lines)
+    return next((i for i in range(start, len(lines)) if not lines[i].strip()), len(lines))
 
 
 def _strip_no_overloads_directive(lines: list[str]) -> bool:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,8 +6,11 @@ from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 from conftest import make_docstring_app, make_sig_app
+from docutils.frontend import get_default_settings
+from docutils.parsers.rst import Parser
 from sphinx.application import Sphinx
 from sphinx.config import Config
+from sphinx.ext.autosummary import extract_summary
 
 import sphinx_autodoc_typehints as sat
 from sphinx_autodoc_typehints import (
@@ -152,6 +155,25 @@ def test_inject_overload_empty_overloads_returns_false() -> None:
         assert _inject_overload_signatures(app, "function", "name", obj, []) is False
     finally:
         _OVERLOADS_CACHE.pop("test_mod2", None)
+
+
+def test_inject_overload_keeps_summary_first() -> None:
+    """Overloads must follow the summary so autosummary can still extract it (#730)."""
+    obj = MagicMock()
+    obj.__module__ = "test_mod"
+    obj.__qualname__ = "func"
+    sig = inspect.Signature(
+        parameters=[inspect.Parameter("x", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=int)],
+        return_annotation=str,
+    )
+    _OVERLOADS_CACHE["test_mod"] = {"func": [sig]}
+    try:
+        app = make_docstring_app()
+        lines = ["Run the thing.", "", ":param x: the x"]
+        assert _inject_overload_signatures(app, "function", "name", obj, lines) is True
+        assert extract_summary(lines, get_default_settings(Parser())) == "Run the thing."
+    finally:
+        _OVERLOADS_CACHE.pop("test_mod", None)
 
 
 def test_local_function_warning_includes_location() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -843,13 +843,13 @@ def func_with_overload(a: str, b: str) -> None: ...
     """\
 mod.func_with_overload(a, b)
 
+   f does the thing. The arguments can either be ints or strings but
+   they must both have the same type.
+
    Overloads:
       * **a** (int), **b** (int) → None
 
       * **a** (str), **b** (str) → None
-
-   f does the thing. The arguments can either be ints or strings but
-   they must both have the same type.
 
    Parameters:
       * **a** ("int" | "str") -- The first thing
@@ -883,12 +883,12 @@ def overload_with_complex_types(x: dict[str, int]) -> list[int]: ...
     """\
 mod.overload_with_complex_types(x)
 
+   Function with overloaded complex types.
+
    Overloads:
       * **x** (list[int]) → dict[str, int]
 
       * **x** (dict[str, int]) → list[int]
-
-   Function with overloaded complex types.
 
    Parameters:
       **x** ("list"["int"] | "dict"["str", "int"]) -- Input value


### PR DESCRIPTION
PR #625 (shipped in 3.8.0) started prepending the overload field list to a function docstring. autosummary builds its one-line summary by running `extract_summary` over the processed docstring, and that function reads the first stanza: with a `:Overloads:` field list on top it returns an empty summary rather than the real text, so autosummary boxes for overloaded functions went blank.

The fix inserts the overload block after the summary paragraph instead of at the top, so `extract_summary` still finds the summary while the overloads keep rendering in the full autodoc output.

Added a regression test that runs `extract_summary` over an injected docstring and asserts the summary survives; it fails on the old prepend behavior.

Fixes #730