### PR TITLE
🐛 fix(annotations): use py:class for types on 3.13+

### DIFF
--- a/src/sphinx_autodoc_typehints/_annotations.py
+++ b/src/sphinx_autodoc_typehints/_annotations.py
@@ -38,18 +38,20 @@ _PYDATA_ANNOTS_TYPING = {
     "Tuple",
     *({"Union"} if sys.version_info < (3, 14) else set()),
 }
-_PYDATA_ANNOTS_TYPES = {
-    *("AsyncGeneratorType", "BuiltinFunctionType", "BuiltinMethodType"),
-    *("CellType", "ClassMethodDescriptorType", "CoroutineType"),
-    *("FrameType", "FunctionType"),
-    *("GeneratorType", "GetSetDescriptorType"),
-    "LambdaType",
-    *("MemberDescriptorType", "MethodDescriptorType", "MethodType", "MethodWrapperType"),
-    "NoneType",
-    "WrapperDescriptorType",
-    # documented as ``py:class`` since the Python 3.13 docs
-    *({"EllipsisType", "NotImplementedType"} if sys.version_info < (3, 13) else set()),
-}
+# The types module documents these as ``py:data`` through 3.12 and as ``py:class`` from 3.13 on.
+_PYDATA_ANNOTS_TYPES = (
+    {
+        *("AsyncGeneratorType", "BuiltinFunctionType", "BuiltinMethodType"),
+        *("CellType", "ClassMethodDescriptorType", "CoroutineType"),
+        *("EllipsisType", "FrameType", "FunctionType"),
+        *("GeneratorType", "GetSetDescriptorType"),
+        "LambdaType",
+        *("MemberDescriptorType", "MethodDescriptorType", "MethodType", "MethodWrapperType"),
+        *("NoneType", "NotImplementedType", "WrapperDescriptorType"),
+    }
+    if sys.version_info < (3, 13)
+    else set()
+)
 _PYDATA_ANNOTATIONS = {
     *(("typing", n) for n in _PYDATA_ANNOTS_TYPING),
     *(("types", n) for n in _PYDATA_ANNOTS_TYPES),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -167,8 +167,16 @@ _CASES = [
         f":py:{'class' if sys.version_info >= (3, 13) else 'data'}:`~types.EllipsisType`",
         id="EllipsisType",
     ),
-    pytest.param(FunctionType, ":py:data:`~types.FunctionType`", id="FunctionType"),
-    pytest.param(FrameType, ":py:data:`~types.FrameType`", id="FrameType"),
+    pytest.param(
+        FunctionType,
+        f":py:{'class' if sys.version_info >= (3, 13) else 'data'}:`~types.FunctionType`",
+        id="FunctionType",
+    ),
+    pytest.param(
+        FrameType,
+        f":py:{'class' if sys.version_info >= (3, 13) else 'data'}:`~types.FrameType`",
+        id="FrameType",
+    ),
     pytest.param(ModuleType, ":py:class:`~types.ModuleType`", id="ModuleType"),
     pytest.param(
         NotImplementedType,


### PR DESCRIPTION
The `inv` test fixture cross-checks every emitted cross-reference role against the live `docs.python.org/<ver>/objects.inv`. Python 3.13 reclassified the entire `types` module from `:py:data:` to `:py:class:` (3.12 still uses `:py:data:`), so the `:py:data:` references we emit for `types.FunctionType`, `types.FrameType`, and the rest no longer resolve on 3.13+, and `test_format_annotation[FunctionType]`/`[FrameType]` fail on 3.13/3.14.

The file already gated `EllipsisType`/`NotImplementedType` this way. This extends the gate to the whole `types.*` set: populated on 3.12 and below, empty from 3.13 on, so `format_annotation` emits `:py:class:` there to match the docs. Updated the two hardcoded test expectations to the same version conditional already used for `EllipsisType`.

Verified against the live 3.12/3.13/3.14 inventories: all `types.*` names are `data` on 3.12 and `class` on 3.13 and 3.14.