### PR TITLE
🐛 fix(resolver): stop TYPE_CHECKING and stub gaps cascading

### DIFF
--- a/src/sphinx_autodoc_typehints/_resolver/_stubs.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_stubs.py
@@ -27,11 +27,15 @@ def _backfill_from_stub(obj: Any) -> dict[str, str]:
 
 def _get_stub_context(obj: Any) -> tuple[dict[str, Any], set[str], str]:
     """
-    Return (localns, alias_names, owner_module_name) from the stub owning *obj*.
+    Return (localns, crossref_names, owner_module_name) from the stub owning *obj*.
 
     Single lookup avoids duplicate ``_find_stub_owner`` / ``_parse_stub_ast`` calls. The owner module name lets callers
     use ``vars(sys.modules[name])`` as the correct globalns — important when a C extension function lives in a child
     module but its stub belongs to a parent package (e.g. ``cbor2._cbor2.dumps`` → ``cbor2/__init__.pyi``).
+
+    Crossref names are the stub's type aliases plus every name it imports that has no runtime counterpart, such as
+    numpy's ``_SeriesLikeCoef_co`` living in the stub-only ``numpy/polynomial/_polytypes.pyi``. Both render as a plain
+    cross-reference instead of failing to evaluate.
     """
     if (info := _find_stub_owner(obj)) is None:
         return {}, set(), ""
@@ -39,8 +43,9 @@ def _get_stub_context(obj: Any) -> tuple[dict[str, Any], set[str], str]:
     if (tree := _parse_stub_ast(stub_path)) is None:
         return {}, set(), ""
     ns: dict[str, Any] = dict(vars(owner_module))
-    ns.update(_resolve_stub_imports(tree, _stub_owner_package(owner_module, stub_path)))
-    return ns, _extract_type_alias_names(tree), owner_module.__name__
+    resolved, unresolved = _resolve_stub_imports(tree, _stub_owner_package(owner_module, stub_path))
+    ns.update(resolved)
+    return ns, _extract_type_alias_names(tree) | (unresolved - ns.keys()), owner_module.__name__
 
 
 def _stub_owner_package(owner_module: types.ModuleType, stub_path: Path) -> str:
@@ -54,22 +59,25 @@ def _stub_owner_package(owner_module: types.ModuleType, stub_path: Path) -> str:
     return owner_name.rpartition(".")[0]
 
 
-def _resolve_stub_imports(tree: ast.Module, owner_package: str = "") -> dict[str, Any]:
+def _resolve_stub_imports(tree: ast.Module, owner_package: str = "") -> tuple[dict[str, Any], set[str]]:
     ns: dict[str, Any] = {}
-    _resolve_stub_imports_from_body(tree.body, owner_package, ns)
+    unresolved: set[str] = set()
+    _resolve_stub_imports_from_body(tree.body, owner_package, ns, unresolved)
     _resolve_stub_definitions(tree.body, ns)
-    return ns
+    return ns, unresolved - ns.keys()
 
 
-def _resolve_stub_imports_from_body(body: list[ast.stmt], owner_package: str, ns: dict[str, Any]) -> None:
+def _resolve_stub_imports_from_body(
+    body: list[ast.stmt], owner_package: str, ns: dict[str, Any], unresolved: set[str]
+) -> None:
     for node in body:
         if isinstance(node, ast.Import):
             _resolve_import_node(node, ns)
         elif isinstance(node, ast.ImportFrom):
-            _resolve_import_from_node(node, owner_package, ns)
+            _resolve_import_from_node(node, owner_package, ns, unresolved)
         elif isinstance(node, ast.If):
-            _resolve_stub_imports_from_body(node.body, owner_package, ns)
-            _resolve_stub_imports_from_body(node.orelse, owner_package, ns)
+            _resolve_stub_imports_from_body(node.body, owner_package, ns, unresolved)
+            _resolve_stub_imports_from_body(node.orelse, owner_package, ns, unresolved)
 
 
 _STUB_DEFINITION_TYPES = (ast.Assign, ast.AnnAssign, ast.ClassDef, ast.TypeAlias)
@@ -104,19 +112,26 @@ def _resolve_import_node(node: ast.Import, ns: dict[str, Any]) -> None:
                 ns[top] = importlib.import_module(top)
 
 
-def _resolve_import_from_node(node: ast.ImportFrom, owner_package: str, ns: dict[str, Any]) -> None:
-    if (module_name := _resolve_import_from(node, owner_package)) is None:
-        return
-    try:
-        mod = importlib.import_module(module_name)
-    except ImportError:
-        return
+def _resolve_import_from_node(
+    node: ast.ImportFrom, owner_package: str, ns: dict[str, Any], unresolved: set[str]
+) -> None:
+    module_name = _resolve_import_from(node, owner_package)
+    mod = _import_module_or_none(module_name) if module_name else None
     for alias in node.names:
         if alias.name == "*":
             continue
         name = alias.asname or alias.name
-        if (val := getattr(mod, alias.name, None)) is not None:
+        if mod is not None and (val := getattr(mod, alias.name, None)) is not None:
             ns[name] = val
+        else:
+            unresolved.add(name)
+
+
+def _import_module_or_none(module_name: str) -> types.ModuleType | None:
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        return None
 
 
 def _resolve_import_from(node: ast.ImportFrom, owner_package: str) -> str | None:

--- a/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
@@ -51,17 +51,17 @@ def get_all_type_hints(
         stub_obj = _stub_target(obj) if inspect.isclass(obj) else obj
         result = backfill_type_hints(stub_obj, name)
         stub_localns: dict[str, Any] = {}
-        stub_alias_names: set[str] = set()
+        stub_crossref_names: set[str] = set()
         stub_owner_module: str = ""
         if not result:
             result = _backfill_from_stub(stub_obj)
             if result:
-                stub_localns, stub_alias_names, stub_owner_module = _get_stub_context(stub_obj)
+                stub_localns, stub_crossref_names, stub_owner_module = _get_stub_context(stub_obj)
         combined_localns = {**stub_localns, **localns}
-        for alias_name in stub_alias_names:
-            ref = MyTypeAliasForwardRef(alias_name)
+        for crossref_name in stub_crossref_names:
+            ref = MyTypeAliasForwardRef(crossref_name)
             ref.crossref = True
-            combined_localns[alias_name] = ref
+            combined_localns[crossref_name] = ref
         try:
             obj.__annotations__ = result
         except (AttributeError, TypeError):
@@ -93,11 +93,11 @@ def get_descriptor_type_hint(obj: Any) -> Any | None:
     """
     if (annotation := _backfill_descriptor_annotation(obj)) is None:
         return None
-    localns, alias_names, owner_module = _get_stub_context(obj)
-    for alias_name in alias_names:
-        ref = MyTypeAliasForwardRef(alias_name)
+    localns, crossref_names, owner_module = _get_stub_context(obj)
+    for crossref_name in crossref_names:
+        ref = MyTypeAliasForwardRef(crossref_name)
         ref.crossref = True
-        localns[alias_name] = ref
+        localns[crossref_name] = ref
     return _resolve_string_annotations(obj, {"return": annotation}, localns, owner_module)["return"]
 
 

--- a/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import importlib
 import inspect
@@ -198,19 +199,28 @@ def _should_skip_guarded_import_resolution(obj: Any) -> bool:
 
 def _execute_guarded_code(autodoc_mock_imports: list[str], obj: Any, module_code: str) -> None:
     for _, part in _TYPE_GUARD_IMPORT_RE.findall(module_code):
-        guarded_code = textwrap.dedent(part)
         try:
-            _run_guarded_import(autodoc_mock_imports, obj, guarded_code)
-        except Exception as exc:  # ruff:ignore[blind-except]
-            module_name = getattr(obj, "__module__", None) or getattr(obj, "__name__", "?")
-            _LOGGER.warning(
-                "Failed guarded type import in %r: %r",
-                module_name,
-                exc,
-                type="sphinx_autodoc_typehints",
-                subtype="guarded_import",
-                location=get_obj_location(obj),
-            )
+            # One statement at a time, so an unimportable optional dependency cannot strand the names after it — #741
+            statements = [ast.unparse(node) for node in ast.parse(textwrap.dedent(part)).body]
+        except SyntaxError as exc:
+            _warn_guarded_import(obj, exc)
+            continue
+        for statement in statements:
+            try:
+                _run_guarded_import(autodoc_mock_imports, obj, statement)
+            except Exception as exc:  # ruff:ignore[blind-except]
+                _warn_guarded_import(obj, exc)
+
+
+def _warn_guarded_import(obj: Any, exc: Exception) -> None:
+    _LOGGER.warning(
+        "Failed guarded type import in %r: %r",
+        getattr(obj, "__module__", None) or getattr(obj, "__name__", "?"),
+        exc,
+        type="sphinx_autodoc_typehints",
+        subtype="guarded_import",
+        location=get_obj_location(obj),
+    )
 
 
 def _run_guarded_import(autodoc_mock_imports: list[str], obj: Any, guarded_code: str) -> None:

--- a/tests/test_resolver/test_stubs.py
+++ b/tests/test_resolver/test_stubs.py
@@ -325,24 +325,26 @@ def test_backfill_from_stub_no_stub() -> None:
 
 
 @pytest.mark.parametrize(
-    ("source", "expected"),
+    ("source", "expected", "expected_unresolved"),
     [
-        pytest.param("import os\nimport sys\n", {"os": os, "sys": sys}, id="basic_import"),
-        pytest.param("import os as operating_system\n", {"operating_system": os}, id="import_as"),
-        pytest.param("import os.path\n", {"os": os}, id="dotted_import"),
-        pytest.param("from typing import Optional, Any\n", {"Optional": Optional, "Any": Any}, id="from_import"),
-        pytest.param("from typing import Optional as Opt\n", {"Opt": Optional}, id="from_import_as"),
-        pytest.param("from typing import *\n", {}, id="star_import_skipped"),
-        pytest.param("import nonexistent_xyz\nfrom nonexistent_abc import Foo\n", {}, id="missing_module_skipped"),
-        pytest.param("from typing import NonExistentThing\n", {}, id="missing_attr_skipped"),
+        pytest.param("import os\nimport sys\n", {"os": os, "sys": sys}, set(), id="basic_import"),
+        pytest.param("import os as operating_system\n", {"operating_system": os}, set(), id="import_as"),
+        pytest.param("import os.path\n", {"os": os}, set(), id="dotted_import"),
+        pytest.param("from typing import Optional, Any\n", {"Optional": Optional, "Any": Any}, set(), id="from_import"),
+        pytest.param("from typing import Optional as Opt\n", {"Opt": Optional}, set(), id="from_import_as"),
+        pytest.param("from typing import *\n", {}, set(), id="star_import_skipped"),
+        pytest.param("import nonexistent_xyz\n", {}, set(), id="missing_module_import_skipped"),
+        pytest.param("from nonexistent_abc import Foo\n", {}, {"Foo"}, id="missing_module_from_import"),
+        pytest.param("from typing import NonExistentThing\n", {}, {"NonExistentThing"}, id="missing_attr"),
     ],
 )
-def test_resolve_stub_imports(source: str, expected: dict[str, Any]) -> None:
-    ns = _resolve_stub_imports(ast.parse(source))
+def test_resolve_stub_imports(source: str, expected: dict[str, Any], expected_unresolved: set[str]) -> None:
+    ns, unresolved = _resolve_stub_imports(ast.parse(source))
     for key, val in expected.items():
         assert ns[key] is val
     if not expected:
         assert ns == {}
+    assert unresolved == expected_unresolved
 
 
 @pytest.mark.parametrize(
@@ -619,7 +621,7 @@ def test_resolve_stub_imports_handles_conditional_blocks() -> None:
             from typing_extensions import Self
     """)
     tree = ast.parse(source)
-    ns = _resolve_stub_imports(tree, "")
+    ns, _ = _resolve_stub_imports(tree, "")
     assert "os" in ns
     assert "Self" in ns
 
@@ -632,7 +634,7 @@ def test_resolve_stub_definitions_evaluates_typevars_and_classes() -> None:
             x: int
     """)
     tree = ast.parse(source)
-    ns = _resolve_stub_imports(tree, "")
+    ns, _ = _resolve_stub_imports(tree, "")
     assert "_T" in ns
     assert "MyDict" in ns
 
@@ -641,7 +643,7 @@ def test_resolve_stub_imports_relative() -> None:
     source = "from .typing import ColorType\nfrom typing import Any\n"
     tree = ast.parse(source)
     # matplotlib.typing.ColorType is a type alias, check it resolves to something
-    ns = _resolve_stub_imports(tree, "matplotlib")
+    ns, _ = _resolve_stub_imports(tree, "matplotlib")
     assert "Any" in ns
     assert ns["Any"] is Any
 

--- a/tests/test_resolver/test_type_hints.py
+++ b/tests/test_resolver/test_type_hints.py
@@ -365,6 +365,28 @@ def test_stub_annotations_not_polluted_on_repeated_calls(tmp_path: Path) -> None
         _TYPE_GUARD_IMPORTS_RESOLVED.discard("stubpkg.mod")
 
 
+def test_get_all_type_hints_crossrefs_names_from_stub_only_modules(tmp_path: Path) -> None:
+    """numpy's _polybase.pyi imports from _polytypes.pyi, which ships no runtime module (issue #741)."""
+    pkg = tmp_path / "stubonlypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "_types.pyi").write_text("from typing import Any\n_SeriesLike = Any\n")
+    (pkg / "poly.py").write_text("class Poly:\n    def __init__(self, coef): ...\n")
+    (pkg / "poly.pyi").write_text(
+        "from ._types import _SeriesLike\nclass Poly:\n    def __init__(self, coef: _SeriesLike) -> None: ...\n"
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        mod = importlib.import_module("stubonlypkg.poly")
+        hint = get_all_type_hints([], mod.Poly, "stubonlypkg.poly.Poly", {})["coef"]
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in [n for n in sys.modules if n.startswith("stubonlypkg")]:
+            del sys.modules[name]
+    assert isinstance(hint, MyTypeAliasForwardRef)
+    assert hint.name == "_SeriesLike"
+
+
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="annotationlib requires Python 3.14+")
 def test_get_type_hint_uses_annotationlib_on_name_error() -> None:  # pragma: >=3.14 cover
     """_get_type_hint falls back to annotationlib.get_annotations on 3.14+ NameError."""

--- a/tests/test_resolver/test_type_hints.py
+++ b/tests/test_resolver/test_type_hints.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import csv
 import importlib
+import re
 import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import sys
 import sysconfig
 import types
-from collections.abc import Sequence
+from collections.abc import Callable, Iterator, Sequence
 from csv import Error
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, TypeAliasType, Union, get_args, get_origin
 from unittest.mock import MagicMock, patch
@@ -142,6 +144,57 @@ def test_guarded_import_warning_includes_module() -> None:
 def test_get_all_type_hints_for_class_owning_the_type_params_slot() -> None:
     """typing.TypeAliasType hands back the __type_params__ descriptor rather than a tuple (issue #740)."""
     assert get_all_type_hints([], TypeAliasType, "mod.TypeAliasType", {}) == {}
+
+
+@pytest.fixture
+def guarded_module(tmp_path: Path, request: pytest.FixtureRequest) -> Iterator[Callable[[str], types.ModuleType]]:
+    name = re.sub(r"\W", "_", request.node.name)
+    sys.path.insert(0, str(tmp_path))
+
+    def build(source: str) -> types.ModuleType:
+        (tmp_path / f"{name}.py").write_text(source)
+        return importlib.import_module(name)
+
+    yield build
+    sys.path.remove(str(tmp_path))
+    sys.modules.pop(name, None)
+
+
+def test_guarded_import_binds_names_below_an_unimportable_one(
+    guarded_module: Callable[[str], types.ModuleType],
+) -> None:
+    """An absent optional dependency must not strand the imports under it (issue #741)."""
+    module = guarded_module(
+        "from __future__ import annotations\n"
+        "from typing import TYPE_CHECKING\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    from no_such_dependency import Absent\n"
+        "    from decimal import Decimal\n"
+        "\n"
+        "def func(value: Decimal) -> None: ...\n"
+    )
+    assert get_all_type_hints([], module.func, f"{module.__name__}.func", {})["value"] is Decimal
+
+
+def test_guarded_import_warns_when_the_block_does_not_parse(
+    guarded_module: Callable[[str], types.ModuleType],
+) -> None:
+    """A block truncated mid-literal by the guard regex is reported rather than raised (issue #741)."""
+    module = guarded_module(
+        "from typing import TYPE_CHECKING\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        '    DOC = """\n'
+        "text\n"
+        '"""\n'
+        "\n"
+        "def func(value: int) -> None: ...\n"
+    )
+    mock_logger = MagicMock()
+    with patch("sphinx_autodoc_typehints._resolver._type_hints._LOGGER", mock_logger):
+        get_all_type_hints([], module.func, f"{module.__name__}.func", {})
+    assert "unterminated triple-quoted string literal" in str(mock_logger.warning.call_args)
 
 
 def test_build_localns_adds_ancestor_classes() -> None:


### PR DESCRIPTION
Docs builds running with `-W` started failing on annotations that belong to third-party code the author does not control, as [#741](https://github.com/tox-dev/sphinx-autodoc-typehints/issues/741) reports against satpy. Two separate causes produce that report; this branch takes on both.

A `TYPE_CHECKING` block went through a single `exec`, so the first name Python could not import aborted every binding below it. [trollsift](https://github.com/pytroll/trollsift/blob/6ae05caf830c1d14ce6a24d6334fa9adcb3690cc/trollsift/parser.py#L12-L16) imports `_typeshed` ahead of `typing.Any`, and [universal-pathlib](https://github.com/fsspec/universal_pathlib/blob/827574045b1fecad52f7af3cfeeab3ecd9a0d0e8/upath/core.py#L62-L75) imports `pydantic` ahead of its `TypeVar` definitions. Neither `Any` nor `_WT` ever got bound, and every annotation naming them drew a `forward_reference` warning. Parsing the block and running one top-level statement at a time confines the damage to the names the missing dependency defines. A block that the guard regex truncates mid-literal still fails to parse, and keeps reporting the syntax error the previous `exec` raised. One consequence to weigh: a block with several unimportable statements reports each of them, where before it stopped at the first.

The second cause sits in the stub reader. Stub packages keep their type vocabulary in `.pyi` files that ship no runtime module, and numpy's `polynomial` classes take their annotations from `_polybase.pyi`, which pulls `_SeriesLikeCoef_co` from the stub-only `_polytypes.pyi`. Evaluating those backfilled annotations raised `NameError`. The reader now tracks names a stub imports but Python cannot supply at runtime, and puts them in the local namespace as cross-references, the treatment the stub's own type aliases get.

Building satpy's two examples against this branch, `numpy.polynomial.Chebyshev` produces no warnings, and `upath.UPath` drops from five to two, both `guarded_import` warnings naming `pydantic` and `pydantic_core`. Installing the dependency or listing that subtype in `suppress_warnings` clears them.

Closes #741
