### PR TITLE
👷 ci(coverage): pick a measurement core that records contexts

### DIFF
--- a/tox.toml
+++ b/tox.toml
@@ -58,13 +58,6 @@ commands = [
   ],
 ]
 
-# 3.15 ships no compiled coverage tracer yet, leaving the pure-Python core as the only one recording contexts
-[env."3.15"]
-set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}", COVERAGE_CORE = "pytrace" }
-
-[env."3.15t"]
-set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}", COVERAGE_CORE = "pytrace" }
-
 [env.fix]
 description = "format the code base to adhere to our styles, and complain about what we cannot do automatically"
 skip_install = true
@@ -91,3 +84,10 @@ description = "generate a DEV environment"
 package = "editable"
 dependency_groups = [ "dev" ]
 commands = [ [ "uv", "pip", "tree" ], [ "python", "-c", "import sys; print(sys.executable)" ] ]
+
+# 3.15 ships no compiled coverage tracer yet, leaving the pure-Python core as the only one recording contexts
+[env."3.15"]
+set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}", COVERAGE_CORE = "pytrace" }
+
+[env."3.15t"]
+set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}", COVERAGE_CORE = "pytrace" }

--- a/tox.toml
+++ b/tox.toml
@@ -21,7 +21,8 @@ package = "wheel"
 wheel_build_env = ".pkg"
 dependency_groups = [ "test" ]
 pass_env = [ "DIFF_AGAINST", "PYTEST_*" ]
-set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}" }
+# sysmon, the coverage core Python 3.14+ defaults to, cannot record the dynamic contexts --cov-context asks for
+set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}", COVERAGE_CORE = "ctrace" }
 commands = [
   [
     "python",
@@ -56,6 +57,13 @@ commands = [
     "100",
   ],
 ]
+
+# 3.15 ships no compiled coverage tracer yet, leaving the pure-Python core as the only one recording contexts
+[env."3.15"]
+set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}", COVERAGE_CORE = "pytrace" }
+
+[env."3.15t"]
+set_env = { COVERAGE_FILE = "{work_dir}/.coverage.{env_name}", COVERAGE_CORE = "pytrace" }
 
 [env.fix]
 description = "format the code base to adhere to our styles, and complain about what we cannot do automatically"


### PR DESCRIPTION
Every test on 3.14, 3.15, and both free-threaded builds errors out before it runs, so four of the nine CI jobs sit red on `main` and on every PR branch. Coverage emits `CoverageWarning: Dynamic contexts aren't supported with core=sysmon` 1461 times, and the `filterwarnings = ["error", ...]` setting promotes each one to an error.

Coverage picks `sysmon` as its measurement core from Python 3.14 on. That core cannot record the per-test contexts `--cov-context=test` asks for, and those contexts feed `html.show_contexts`, so dropping the flag would cost the HTML report. Naming `ctrace` in the run environment keeps the contexts, and it works on the free-threaded builds too.

3.15 needs separate treatment. Coverage builds no compiled tracer for it yet, so `ctrace` there kills the run with `COVERAGE_CORE is 'ctrace' but can't import CTracer!`, which is what the first push of this branch hit. Those two environments take `pytrace` instead. The pure-Python core costs about half again the wall clock, 43s against 28s over this suite, so the faster core stays everywhere it exists. A `set_env` override replaces the base table rather than merging into it, hence `COVERAGE_FILE` repeated in each.

Running all six interpreter environments through tox on this branch, every one finishes green with coverage above 98%.
