### PR TITLE
🐛 fix(parser): stop shadowing intersphinx roles in the rtype probe

### DIFF
--- a/src/sphinx_autodoc_typehints/_formats/_sphinx.py
+++ b/src/sphinx_autodoc_typehints/_formats/_sphinx.py
@@ -15,7 +15,6 @@ from docutils.frontend import get_default_settings
 from docutils.parsers.rst import Directive, directives
 from docutils.utils import new_document
 from sphinx.parsers import RSTParser
-from sphinx.util.docutils import sphinx_domains
 
 from sphinx_autodoc_typehints._parser import _RstSnippetParser
 
@@ -109,13 +108,13 @@ def _safe_parse(inputstr: str, settings: Values | optparse.Values) -> nodes.docu
         return cls, messages
 
     doc = new_document("", settings=settings)  # ty: ignore[invalid-argument-type]
-    with sphinx_domains(settings.env):
-        directives.directive = _safe_directive_lookup  # type: ignore[assignment]
-        try:
-            parser = _RstSnippetParser()
-            parser.parse(inputstr, doc)
-        finally:
-            directives.directive = original_lookup
+    # The read phase already runs inside sphinx_domains; entering it again shadows the intersphinx
+    # dispatcher layered on top of it, losing the external+ roles (#753)
+    directives.directive = _safe_directive_lookup  # type: ignore[assignment]
+    try:
+        _RstSnippetParser().parse(inputstr, doc)
+    finally:
+        directives.directive = original_lookup
     return doc
 
 

--- a/tests/roots/test-intersphinx-external-role/conf.py
+++ b/tests/roots/test-intersphinx-external-role/conf.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import zlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+master_doc = "index"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
+]
+
+# a hand-rolled inventory keeps the fixture offline
+_INVENTORY = pathlib.Path(__file__).parent / "objects.inv"
+_INVENTORY.write_bytes(
+    b"# Sphinx inventory version 2\n"
+    b"# Project: demo\n"
+    b"# Version: 1.0\n"
+    b"# The remainder of this file is compressed using zlib.\n" + zlib.compress(b"index std:doc -1 index.html Demo\n")
+)
+intersphinx_mapping = {"demo": ("https://example.org/demo/", str(_INVENTORY))}

--- a/tests/roots/test-intersphinx-external-role/demo_module.py
+++ b/tests/roots/test-intersphinx-external-role/demo_module.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 def probe(x: int) -> int:
     """
-    Summarise.
+    Summarize.
 
     :param x: see :external+demo:doc:`the demo docs <index>`.
     """

--- a/tests/roots/test-intersphinx-external-role/demo_module.py
+++ b/tests/roots/test-intersphinx-external-role/demo_module.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+def probe(x: int) -> int:
+    """
+    Summarise.
+
+    :param x: see :external+demo:doc:`the demo docs <index>`.
+    """
+    return x

--- a/tests/roots/test-intersphinx-external-role/index.rst
+++ b/tests/roots/test-intersphinx-external-role/index.rst
@@ -1,0 +1,4 @@
+Demo
+====
+
+.. autofunction:: demo_module.probe

--- a/tests/test_safe_parse.py
+++ b/tests/test_safe_parse.py
@@ -1,4 +1,4 @@
-"""Tests that snippet parsing doesn't trigger extension directive side-effects."""
+"""Tests that the throwaway snippet parse leaves the real build untouched."""
 
 from __future__ import annotations
 
@@ -68,3 +68,13 @@ class _TrackingDirective(Directive):
     def run(self) -> list:
         _TrackingDirective.executions.append(self.content[0] if self.content else "")
         return []
+
+
+@pytest.mark.sphinx("text", testroot="intersphinx-external-role")
+def test_intersphinx_role_resolves_during_snippet_parse(
+    app: SphinxTestApp, status: StringIO, warning: StringIO
+) -> None:
+    """The snippet parse must not shadow the intersphinx role dispatcher (#753)."""
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert "unknown role name" not in warning.getvalue()


### PR DESCRIPTION
A docstring that references another project through an `external+...` role made the build emit `unknown role name: external+demo:doc`, as reported in #753. The page rendered fine. Only the warning was wrong, and that was enough to fail any build running Sphinx with `-W`, with no obvious way to suppress it.

Sphinx enters `sphinx_domains` once for the whole read phase and `sphinx.ext.intersphinx` layers `IntersphinxDispatcher` on top of it, which is what claims role names starting with `external+`. The throwaway parse that finds where to put `:rtype:` entered `sphinx_domains` a second time; `CustomReSTDispatcher.enable()` overwrites `docutils.parsers.rst.roles.role`, so the probe replaced the intersphinx layer with a plain domain lookup for its own duration. `external+demo` matched no domain, and Sphinx warned. That probe runs from `autodoc-process-docstring` and nowhere else, where the caller has already installed the dispatcher it needs, so this PR drops the nested context manager and lets the outer one stand. 🔍

The probe still neutralizes non-builtin directives, so extension directives inside docstrings keep running once rather than twice. Roles now behave in the probe as they do in the real parse. A role the outer dispatcher cannot resolve still warns, from the real parse.
