### PR TITLE
🧪 test(docstring): pin what a nested handler restores

### DIFF
--- a/tests/roots/test-reentrant-formatter/conf.py
+++ b/tests/roots/test-reentrant-formatter/conf.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import TYPE_CHECKING, Any
+
+from sphinx_autodoc_typehints import process_docstring
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+master_doc = "index"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
+]
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+    from sphinx.config import Config
+
+
+def setup(app: Sphinx) -> None:
+    """Install a formatter that documents a second object, re-entering the docstring handler."""
+
+    def inner(flag: str) -> str: ...
+
+    def formatter(annotation: Any, config: Config) -> None:  # ruff:ignore[unused-function-argument]
+        if annotation is bool:
+            process_docstring(app, "function", "inner_mod.inner", inner, None, ["Inner.", "", ":return: it"])
+
+    app.config.typehints_formatter = formatter

--- a/tests/roots/test-reentrant-formatter/demo_reentrant.py
+++ b/tests/roots/test-reentrant-formatter/demo_reentrant.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+def outer(flag: bool) -> bool:
+    """
+    Outer.
+
+    :param flag: the flag
+    :return: it
+    """
+    return flag

--- a/tests/roots/test-reentrant-formatter/index.rst
+++ b/tests/roots/test-reentrant-formatter/index.rst
@@ -1,0 +1,1 @@
+.. autofunction:: demo_reentrant.outer

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -433,21 +433,23 @@ def test_setup_returns_version() -> None:
 
 
 def test_process_docstring_reentrant_call_keeps_outer_state() -> None:
-    """A formatter documenting a second object must not break the outer teardown (#750)."""
+    """A nested call must hand the outer one its own state back (#750)."""
 
     def inner(flag: str) -> str: ...
 
     def outer(flag: bool) -> bool: ...
 
     app = make_docstring_app()
+    prefix_after_nesting = []
 
-    def formatter(annotation: Any, config: Config) -> None:  # ruff:ignore[unused-function-argument]
+    def formatter(annotation: Any, config: Config) -> None:
         if annotation is bool:
-            process_docstring(app, "function", "test.inner", inner, None, ["Inner.", "", ":return: it"])
+            process_docstring(app, "function", "inner_mod.inner", inner, None, ["Inner.", "", ":return: it"])
+            prefix_after_nesting.append(config._typehints_module_prefix)  # ruff:ignore[private-member-access]
 
     app.config.typehints_formatter = formatter
     lines = ["Outer.", "", ":param flag: the flag", ":return: it"]
-    process_docstring(app, "function", "test.outer", outer, None, lines)
+    process_docstring(app, "function", "outer_mod.outer", outer, None, lines)
     bool_type = ":sphinx_autodoc_typehints_type:`\\:py\\:class\\:\\`bool\\``"
     assert lines == [
         "Outer.",
@@ -458,3 +460,4 @@ def test_process_docstring_reentrant_call_keeps_outer_state() -> None:
         f":rtype: {bool_type}",
         ":return: it",
     ]
+    assert prefix_after_nesting == ["outer_mod", "outer_mod"]

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -395,6 +395,14 @@ def test_resolve_typing_guard_attrs_imports(app: SphinxTestApp, status: StringIO
     assert not warning.getvalue()
 
 
+@pytest.mark.sphinx("text", testroot="reentrant-formatter")
+def test_reentrant_formatter_keeps_the_build_alive(app: SphinxTestApp, status: StringIO, warning: StringIO) -> None:
+    """A formatter documenting a second object must not abort the build (#750)."""
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert not warning.getvalue()
+
+
 @pytest.mark.sphinx("text", testroot="dummy")
 def test_sphinx_output_formatter_no_use_rtype(app: SphinxTestApp, status: StringIO) -> None:
     app.config.master_doc = "simple_no_use_rtype"  # create flag


### PR DESCRIPTION
`_annotation_state` publishes three values on the config and restores what was there, so a nested `process_docstring` hands the outer call its own values back. The tests covered only the surviving build. Since `bool` renders the same whatever `_typehints_module_prefix` holds, a teardown restoring `""` in place of the saved value passes the whole suite.

The unit test now puts the two objects in different modules and reads the prefix back inside the formatter, after the nested call returns. A clobbered restore shows up as `["", ""]` where `["outer_mod", "outer_mod"]` belongs. A second test drives the same re-entry through a real build, against the real `sphinx.config.Config`: deleting an attribute that was never set raises `AttributeError` there, while the `create_autospec(Config)` mock that `tests/test_init.py` shares treats it as a silent no-op. That gap has the shape of the crash in #750, so the fix deserves a test running against the object that broke. 🔁
