### PR TITLE
🐛 fix(resolver): bind only what a guarded statement defines

### DIFF
--- a/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
+++ b/src/sphinx_autodoc_typehints/_resolver/_type_hints.py
@@ -25,7 +25,7 @@ if sys.version_info >= (3, 14):  # pragma: >=3.14 cover
     import annotationlib
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -209,9 +209,10 @@ def _execute_guarded_code(autodoc_mock_imports: list[str], obj: Any, module_code
             try:
                 _run_guarded_import(autodoc_mock_imports, obj, ast.unparse(statement))
             except Exception as exc:  # ruff:ignore[blind-except]
-                if isinstance(statement, ast.Import | ast.ImportFrom):
+                if any(isinstance(node, ast.Import | ast.ImportFrom) for node in ast.walk(statement)):
                     _warn_guarded_import(obj, exc)
                 else:
+                    _LOGGER.debug("Skipped guarded statement the interpreter rejects: %r", exc)
                     _bind_unresolvable_names(obj, statement)
 
 
@@ -232,13 +233,23 @@ def _bind_unresolvable_names(obj: Any, statement: ast.stmt) -> None:
 
     Type checkers accept constructs the interpreter rejects, e.g. ``TypeVar("T", bound="A" | B)`` (#751).
     """
-    if isinstance(statement, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
-        names = [statement.name]
-    else:
-        names = [n.id for n in ast.walk(statement) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)]
     namespace = getattr(obj, "__globals__", obj.__dict__)
-    for name in names:
+    for name in _defined_names(statement):
         namespace.setdefault(name, MyTypeAliasForwardRef(name))
+
+
+def _defined_names(node: ast.AST) -> Iterator[str]:
+    """Names the node binds, taking only its own targets so loop and comprehension variables stay out."""
+    if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+        yield node.name
+    elif isinstance(node, ast.Assign):
+        yield from (target.id for target in node.targets if isinstance(target, ast.Name))
+    elif isinstance(node, ast.AnnAssign):
+        if isinstance(node.target, ast.Name):
+            yield node.target.id
+    elif isinstance(node, ast.stmt):
+        for child in ast.iter_child_nodes(node):
+            yield from _defined_names(child)
 
 
 def _run_guarded_import(autodoc_mock_imports: list[str], obj: Any, guarded_code: str) -> None:

--- a/tests/test_resolver/test_type_hints.py
+++ b/tests/test_resolver/test_type_hints.py
@@ -197,6 +197,68 @@ def test_guarded_import_warns_when_the_block_does_not_parse(
     assert "unterminated triple-quoted string literal" in str(mock_logger.warning.call_args)
 
 
+def test_guarded_import_warns_when_a_compound_statement_hides_it(
+    guarded_module: Callable[[str], types.ModuleType],
+) -> None:
+    """A version gated or try/except import still reports the absent dependency (issue #751)."""
+    module = guarded_module(
+        "from __future__ import annotations\n"
+        "from typing import TYPE_CHECKING\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    try:\n"
+        "        from no_such_dependency import Absent\n"
+        "    except ImportError:\n"
+        "        from no_such_fallback import Absent\n"
+        "\n"
+        "def func(value: Absent) -> None: ...\n"
+    )
+    mock_logger = MagicMock()
+    with patch("sphinx_autodoc_typehints._resolver._type_hints._LOGGER", mock_logger):
+        get_all_type_hints([], module.func, f"{module.__name__}.func", {})
+    assert "Failed guarded type import" in str(mock_logger.warning.call_args_list)
+
+
+def test_guarded_comprehension_target_leaves_the_builtin_alone(
+    guarded_module: Callable[[str], types.ModuleType],
+) -> None:
+    """Only the statement's own targets are stood in, so a comprehension variable cannot shadow a builtin (#751)."""
+    module = guarded_module(
+        "from __future__ import annotations\n"
+        "from typing import TYPE_CHECKING\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    from decimal import Decimal\n"
+        "    REGISTRY = {type: Decimal[type] for type in (int, str)}\n"
+        "\n"
+        "def func(value: type, registry: REGISTRY) -> None: ...\n"
+    )
+    hints = get_all_type_hints([], module.func, f"{module.__name__}.func", {})
+    assert hints["value"] is type
+    assert hints["registry"].name == "REGISTRY"
+
+
+def test_guarded_version_gated_alias_binds_its_name(
+    guarded_module: Callable[[str], types.ModuleType],
+) -> None:
+    """A failing annotated assignment nested in a version check still leaves its name usable (#751)."""
+    module = guarded_module(
+        "from __future__ import annotations\n"
+        "import sys\n"
+        "from typing import TYPE_CHECKING, TypeAlias\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    from decimal import Decimal\n"
+        "    if sys.version_info >= (3, 12):\n"
+        "        Coords: TypeAlias = Decimal[int]\n"
+        "    else:\n"
+        "        Coords: TypeAlias = Decimal\n"
+        "\n"
+        "def func(value: Coords) -> None: ...\n"
+    )
+    assert get_all_type_hints([], module.func, f"{module.__name__}.func", {})["value"].name == "Coords"
+
+
 def test_build_localns_adds_ancestor_classes() -> None:
     import tests.roots.test_nested_attrs_localns as mod  # ruff:ignore[import-outside-top-level]
 


### PR DESCRIPTION
A `TYPE_CHECKING` statement that fails to execute has its names stood in as forward references, so annotations using them still resolve. Collecting those names walked the statement's whole subtree for Store-context names, which also picks up comprehension, loop and `with ... as` targets. The module holds no such names at runtime, so binding them created them: a guarded `REGISTRY = {type: Dataset[type] for type in (int, str)}` put a placeholder under `type` in the module globals, after which `def describe(value: type)` resolved to the placeholder in place of the builtin. The parameter rendered as unlinked text, and calling the function in the same process raised `TypeError: TypeAliasForwardRef.__call__() takes 1 positional argument but 2 were given`. Only the statement's own targets are read now, recursing into the bodies of the statements it wraps. 🧹

The `Failed guarded type import` warning asked whether the failing statement was an `ast.Import` or `ast.ImportFrom`, which misses the shapes guarded imports tend to take:

```python
if TYPE_CHECKING:
    if sys.version_info >= (3, 11):
        from typing import Self
    else:
        from typing_extensions import Self

    try:
        from orjson import Fragment
    except ImportError:
        from json_fallback import Fragment
```

There the import is a leaf of an `ast.If` or an `ast.Try`, so a dependency missing from the docs environment went unreported, and the name binding could not make up for it either, because `ast.alias` is not an `ast.Name`. The check now looks for an import anywhere in the statement, restoring the diagnostic #741 asked for. Statements that stay silent leave a `_LOGGER.debug` line, so a typo in a guard stays traceable with `-vv`.
