### PR TITLE
🐛 fix(parser): stop shadowing intersphinx roles in the type role

### DIFF
--- a/src/sphinx_autodoc_typehints/_formats/_sphinx.py
+++ b/src/sphinx_autodoc_typehints/_formats/_sphinx.py
@@ -15,6 +15,7 @@ from docutils.frontend import get_default_settings
 from docutils.parsers.rst import Directive, directives
 from docutils.utils import new_document
 from sphinx.parsers import RSTParser
+from sphinx.util import logging
 
 from sphinx_autodoc_typehints._parser import _RstSnippetParser
 
@@ -112,7 +113,10 @@ def _safe_parse(inputstr: str, settings: Values | optparse.Values) -> nodes.docu
     # dispatcher layered on top of it, losing the external+ roles (#753)
     directives.directive = _safe_directive_lookup  # type: ignore[assignment]
     try:
-        _RstSnippetParser().parse(inputstr, doc)
+        # Whatever this parse has to say about the docstring, the real parse says again with the
+        # right line number, so its warnings are only duplicates
+        with logging.suppress_logging():
+            _RstSnippetParser().parse(inputstr, doc)
     finally:
         directives.directive = original_lookup
     return doc

--- a/src/sphinx_autodoc_typehints/_parser.py
+++ b/src/sphinx_autodoc_typehints/_parser.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from docutils.utils import new_document
 from sphinx.parsers import RSTParser
-from sphinx.util.docutils import sphinx_domains
 
 if TYPE_CHECKING:
     import optparse
@@ -23,9 +22,9 @@ class _RstSnippetParser(RSTParser):
 
 
 def parse(inputstr: str, settings: Values | optparse.Values) -> nodes.document:
-    """Parse inputstr and return a docutils document."""
+    """Parse inputstr and return a docutils document. Callers must already be inside ``sphinx_domains``."""
     doc = new_document("", settings=settings)  # ty: ignore[invalid-argument-type]
-    with sphinx_domains(settings.env):
-        parser = _RstSnippetParser()
-        parser.parse(inputstr, doc)
+    # Entering sphinx_domains again shadows the intersphinx dispatcher layered on top of it,
+    # losing the external+ roles the read phase resolves (#753)
+    _RstSnippetParser().parse(inputstr, doc)
     return doc

--- a/tests/roots/test-intersphinx-external-role/conf.py
+++ b/tests/roots/test-intersphinx-external-role/conf.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import pathlib
 import sys
 import zlib
+from typing import TYPE_CHECKING, Any
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+if TYPE_CHECKING:
+    from sphinx.config import Config
 
 master_doc = "index"
 
@@ -23,3 +27,8 @@ _INVENTORY.write_bytes(
     b"# The remainder of this file is compressed using zlib.\n" + zlib.compress(b"index std:doc -1 index.html Demo\n")
 )
 intersphinx_mapping = {"demo": ("https://example.org/demo/", str(_INVENTORY))}
+
+
+def typehints_formatter(annotation: Any, config: Config) -> str | None:  # ruff:ignore[unused-function-argument]
+    """Render one annotation as an intersphinx role, which the type role parses on its own."""
+    return ":external+demo:doc:`the demo docs <index>`" if annotation is bool else None

--- a/tests/roots/test-intersphinx-external-role/demo_module.py
+++ b/tests/roots/test-intersphinx-external-role/demo_module.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 
-def probe(x: int) -> int:
+def probe(x: int, flag: bool) -> int:
     """
     Summarize.
 
     :param x: see :external+demo:doc:`the demo docs <index>`.
+    :param flag: a flag whose type renders as a role.
     """
-    return x
+    return x if flag else -x

--- a/tests/roots/test-intersphinx-missing-inventory/conf.py
+++ b/tests/roots/test-intersphinx-missing-inventory/conf.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+master_doc = "index"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
+]
+intersphinx_mapping: dict[str, tuple[str, str]] = {}

--- a/tests/roots/test-intersphinx-missing-inventory/demo_missing.py
+++ b/tests/roots/test-intersphinx-missing-inventory/demo_missing.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+def probe(x: int) -> int:
+    """
+    Summarize.
+
+    :param x: see :external+nope:doc:`the missing docs <index>`.
+    """
+    return x

--- a/tests/roots/test-intersphinx-missing-inventory/index.rst
+++ b/tests/roots/test-intersphinx-missing-inventory/index.rst
@@ -1,0 +1,4 @@
+Demo
+====
+
+.. autofunction:: demo_missing.probe

--- a/tests/test_safe_parse.py
+++ b/tests/test_safe_parse.py
@@ -74,7 +74,15 @@ class _TrackingDirective(Directive):
 def test_intersphinx_role_resolves_during_snippet_parse(
     app: SphinxTestApp, status: StringIO, warning: StringIO
 ) -> None:
-    """The snippet parse must not shadow the intersphinx role dispatcher (#753)."""
+    """Neither the snippet parse nor the type role may shadow the intersphinx dispatcher (#753)."""
     app.build()
     assert "build succeeded" in status.getvalue()
-    assert "unknown role name" not in warning.getvalue()
+    assert not warning.getvalue()
+
+
+@pytest.mark.sphinx("text", testroot="intersphinx-missing-inventory")
+def test_snippet_parse_stays_quiet(app: SphinxTestApp, status: StringIO, warning: StringIO) -> None:
+    """A reference the role cannot resolve is reported by the real parse alone (#753)."""
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert warning.getvalue().count("inventory for external cross-reference not found") == 1


### PR DESCRIPTION
`sphinx_autodoc_typehints_type_role` wraps every rendered annotation and parses it through `_parser.parse`, which enters `sphinx_domains` though the read phase sits inside it already. The nested layer overwrites `docutils.parsers.rst.roles.role` and hides the intersphinx dispatcher layered above it, so an annotation carrying an `external+` role warns `unknown role name: external+demo:doc`, one warning each, and the rendered page carries the right link all the same. A `typehints_formatter` returning `:external+demo:doc:`...`` is one way to reach it. Dropping the nested context manager leaves the outer one in place, which is what #753 needs.

That makes the role resolve inside the throwaway parse that places `:rtype:`, where it now executes for real, so a role-time intersphinx warning would arrive twice: once from the discarded parse under the line of the `.. autofunction::` directive, once from the real parse under the docstring line. The real parse repeats what the discarded one says and gets the location right, so the probe runs under `suppress_logging`. An unresolvable `external+` reference warns once, at the docstring. 🔇
